### PR TITLE
Use iota for enumerating const log levels

### DIFF
--- a/log.go
+++ b/log.go
@@ -16,13 +16,13 @@ type Level int
 const (
 	// This is a special level used to indicate that no level has been
 	// set and allow for a default to be used.
-	NoLevel Level = 0
+	NoLevel Level = iota
 
-	Trace Level = 1
-	Debug Level = 2
-	Info  Level = 3
-	Warn  Level = 4
-	Error Level = 5
+	Trace
+	Debug
+	Info
+	Warn
+	Error
 )
 
 type Logger interface {

--- a/logger_test.go
+++ b/logger_test.go
@@ -61,7 +61,7 @@ func TestLogger(t *testing.T) {
 
 		lines := strings.Split(buf.String(), "\n")
 
-		assert.Equal(t, "github.com/hashicorp/log.(*intLogger).Stacktrace", lines[1])
+		assert.Equal(t, "github.com/hashicorp/go-log.(*intLogger).Stacktrace", lines[1])
 	})
 
 	t.Run("includes the caller location", func(t *testing.T) {
@@ -83,7 +83,7 @@ func TestLogger(t *testing.T) {
 		rest := str[dataIdx+1:]
 
 		// This test will break if you move this around, it's line dependent, just fyi
-		assert.Equal(t, "[INFO ] log/logger_test.go:76: test: this is test: who=programmer why=\"testing is fun\"\n", rest)
+		assert.Equal(t, "[INFO ] go-log/logger_test.go:76: test: this is test: who=programmer why=\"testing is fun\"\n", rest)
 	})
 }
 


### PR DESCRIPTION
Small change to use `iota` to enum log levels. Updated the expected result from test since the package name is go-log

I was getting this error otherwise:
```
--- FAIL: TestLogger (0.00s)
    --- PASS: TestLogger/formats_log_entries (0.00s)
    --- PASS: TestLogger/quotes_values_with_spaces (0.00s)
    --- FAIL: TestLogger/outputs_stack_traces (0.00s)
        Error Trace:    logger_test.go:64
    	Error:      	Not equal:
    	            	expected: "github.com/hashicorp/log.(*intLogger).Stacktrace"
    	            	actual: "github.com/hashicorp/go-log.(*intLogger).Stacktrace"
    --- FAIL: TestLogger/includes_the_caller_location (0.00s)
        Error Trace:    logger_test.go:86
    	Error:      	Not equal:
    	            	expected: "[INFO ] log/logger_test.go:76: test: this is test: who=programmer why=\"testing is fun\"\n"
    	            	actual: "[INFO ] go-log/logger_test.go:76: test: this is test: who=programmer why=\"testing is fun\"\n"
```