### PR TITLE
Added Printf shorthand for debugging QOL

### DIFF
--- a/global.go
+++ b/global.go
@@ -1,6 +1,7 @@
 package log
 
 import (
+	"fmt"
 	"sync"
 )
 
@@ -31,4 +32,10 @@ func Default() Logger {
 // A short alias for Default()
 func L() Logger {
 	return Default()
+}
+
+// Printf follows the same semantics as log.Printf in the stdlib but uses the
+// default logger.
+func Printf(format string, args ...interface{}) {
+	L().Info(fmt.Sprintf(format, args...))
 }


### PR DESCRIPTION
This copies the Printf interface from stdlib so I can use my muscle memory during development / debugging.

I would prefer to make this a "DEBUG" level but then it won't show up with the default logger.