### PR TITLE
Add log.Helper() func that works like go1.9's test.Helper() func

### DIFF
--- a/global.go
+++ b/global.go
@@ -1,12 +1,15 @@
 package log
 
 import (
+	"runtime"
 	"sync"
 )
 
 var (
-	protect sync.Once
-	def     Logger
+	protect    sync.Once
+	def        Logger
+	helperLock sync.Mutex
+	helpers    map[string]struct{}
 
 	// The options used to create the Default logger. These are
 	// read only when the Default logger is created, so set them
@@ -31,4 +34,32 @@ func Default() Logger {
 // A short alias for Default()
 func L() Logger {
 	return Default()
+}
+
+// Helper marks the calling function as a log helper function when used with
+// IncludeLocation. Instead of logging the line number in the helper func it
+// will log the line number in the function calling the helper.
+func Helper() {
+	helperLock.Lock()
+	defer helperLock.Unlock()
+	if helpers == nil {
+		helpers = make(map[string]struct{})
+	}
+	helpers[callerName(1)] = struct{}{}
+}
+
+// callerName gives the function name (qualified with a package path)
+// for the caller after skip frames (where 0 means the current function).
+//
+// Copied from go stdlib testing package
+func callerName(skip int) string {
+	// Make room for the skip PC.
+	var pc [2]uintptr
+	n := runtime.Callers(skip+2, pc[:]) // skip + runtime.Callers + callerName
+	if n == 0 {
+		panic("testing: zero callers found")
+	}
+	frames := runtime.CallersFrames(pc[:n])
+	frame, _ := frames.Next()
+	return frame.Function
 }

--- a/int.go
+++ b/int.go
@@ -137,7 +137,17 @@ func (z *intLogger) log(t time.Time, level Level, msg string, args ...interface{
 	}
 
 	if z.caller {
-		if _, file, line, ok := runtime.Caller(3); ok {
+		skipLevel := 3
+
+		for {
+			if _, ok := helpers[callerName(skipLevel)]; ok {
+				skipLevel++
+			} else {
+				break
+			}
+		}
+
+		if _, file, line, ok := runtime.Caller(skipLevel); ok {
 			z.w.WriteByte(' ')
 			z.w.WriteString(trimCallerPath(file))
 			z.w.WriteByte(':')
@@ -257,8 +267,19 @@ func (z *intLogger) logJson(t time.Time, level Level, msg string, args ...interf
 	}
 
 	if z.caller {
-		if _, file, line, ok := runtime.Caller(3); ok {
+		skipLevel := 3
+
+		for {
+			if _, ok := helpers[callerName(skipLevel)]; ok {
+				skipLevel++
+			} else {
+				break
+			}
+		}
+
+		if _, file, line, ok := runtime.Caller(skipLevel); ok {
 			vals["@caller"] = fmt.Sprintf("%s:%d", file, line)
+
 		}
 	}
 

--- a/logger_line_test.go
+++ b/logger_line_test.go
@@ -57,15 +57,15 @@ func TestHelper(t *testing.T) {
 			Caller string `json:"@caller"`
 		}
 
-		l := &LogData{}
+		logData := &LogData{}
 
-		if err := json.Unmarshal([]byte(str), l); err != nil {
+		if err := json.Unmarshal([]byte(str), logData); err != nil {
 			t.Fatalf("Failed to convert JSON log data into struct: %s", err)
 		}
 
 		search := "github.com/hashicorp/go-log"
-		dataIdx := strings.Index(l.Caller, search)
-		location := l.Caller[dataIdx+len(search)+1:]
+		dataIdx := strings.Index(logData.Caller, search)
+		location := logData.Caller[dataIdx+len(search)+1:]
 
 		assert.Equal(t, "logger_line_test.go:52", location)
 	})

--- a/logger_line_test.go
+++ b/logger_line_test.go
@@ -1,0 +1,39 @@
+package log
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func WrapperFunc(logger Logger, message string) {
+	Helper()
+	logger.Info(message)
+}
+
+func TestHelper(t *testing.T) {
+	t.Run("formats log entries", func(t *testing.T) {
+		var buf bytes.Buffer
+
+		logger := New(&LoggerOptions{
+			Name:            "test",
+			Output:          &buf,
+			IncludeLocation: true,
+		})
+
+		// The test is going to assert based on the LINE NUMBER OF THIS CALL
+		// so if you edit lines above you will need to change the assert below!
+		logger.Info("this is test", "who", "programmer", "why", "testing")
+
+		str := buf.String()
+
+		dataIdx := strings.IndexByte(str, ' ')
+
+		rest := str[dataIdx+1:]
+
+		assert.Equal(t, "[INFO ] go-log/logger_line_test.go:28: test: this is test: who=programmer why=testing\n", rest)
+	})
+
+}


### PR DESCRIPTION
I basically copied this from Go 1.9's source tree. I wanted to drop this in without touching lots of things but it could be tweaked to integrate better. Lemme know!