### PR TITLE
Add space after bracket

### DIFF
--- a/int.go
+++ b/int.go
@@ -20,8 +20,8 @@ var (
 	_levelToBracket = map[Level]string{
 		Debug: "[DEBUG]",
 		Trace: "[TRACE]",
-		Info:  "[INFO ]",
-		Warn:  "[WARN ]",
+		Info:  "[INFO] ",
+		Warn:  "[WARN] ",
 		Error: "[ERROR]",
 	}
 )

--- a/logger_test.go
+++ b/logger_test.go
@@ -32,7 +32,7 @@ func TestLogger(t *testing.T) {
 		// ts := str[:dataIdx]
 		rest := str[dataIdx+1:]
 
-		assert.Equal(t, "[INFO ] test: this is test: who=programmer why=testing\n", rest)
+		assert.Equal(t, "[INFO]  test: this is test: who=programmer why=testing\n", rest)
 	})
 
 	t.Run("quotes values with spaces", func(t *testing.T) {
@@ -52,7 +52,7 @@ func TestLogger(t *testing.T) {
 		// ts := str[:dataIdx]
 		rest := str[dataIdx+1:]
 
-		assert.Equal(t, "[INFO ] test: this is test: who=programmer why=\"testing is fun\"\n", rest)
+		assert.Equal(t, "[INFO]  test: this is test: who=programmer why=\"testing is fun\"\n", rest)
 	})
 
 	t.Run("outputs stack traces", func(t *testing.T) {
@@ -108,7 +108,7 @@ func TestLogger(t *testing.T) {
 		rest := str[dataIdx+1:]
 
 		// This test will break if you move this around, it's line dependent, just fyi
-		assert.Equal(t, "[INFO ] go-hclog/logger_test.go:101: test: this is test: who=programmer why=\"testing is fun\"\n", rest)
+		assert.Equal(t, "[INFO]  go-hclog/logger_test.go:101: test: this is test: who=programmer why=\"testing is fun\"\n", rest)
 	})
 
 	t.Run("prefixes the name", func(t *testing.T) {
@@ -123,7 +123,7 @@ func TestLogger(t *testing.T) {
 		str := buf.String()
 		dataIdx := strings.IndexByte(str, ' ')
 		rest := str[dataIdx+1:]
-		assert.Equal(t, "[INFO ] this is test\n", rest)
+		assert.Equal(t, "[INFO]  this is test\n", rest)
 
 		buf.Reset()
 
@@ -132,7 +132,7 @@ func TestLogger(t *testing.T) {
 		str = buf.String()
 		dataIdx = strings.IndexByte(str, ' ')
 		rest = str[dataIdx+1:]
-		assert.Equal(t, "[INFO ] sublogger: this is test\n", rest)
+		assert.Equal(t, "[INFO]  sublogger: this is test\n", rest)
 	})
 
 	t.Run("use a different time format", func(t *testing.T) {
@@ -173,14 +173,14 @@ func TestLogger(t *testing.T) {
 		derived1.Info("test1")
 		output := buf.String()
 		dataIdx := strings.IndexByte(output, ' ')
-		assert.Equal(t, "[INFO ] with_test: test1: a=1 b=2 c=3 cat=30\n", output[dataIdx+1:])
+		assert.Equal(t, "[INFO]  with_test: test1: a=1 b=2 c=3 cat=30\n", output[dataIdx+1:])
 
 		buf.Reset()
 
 		derived2.Info("test2")
 		output = buf.String()
 		dataIdx = strings.IndexByte(output, ' ')
-		assert.Equal(t, "[INFO ] with_test: test2: a=1 b=2 c=3 dog=40\n", output[dataIdx+1:])
+		assert.Equal(t, "[INFO]  with_test: test2: a=1 b=2 c=3 dog=40\n", output[dataIdx+1:])
 	})
 
 	t.Run("unpaired with", func(t *testing.T) {
@@ -222,14 +222,14 @@ func TestLogger(t *testing.T) {
 		rootLogger.Info("root_test", "bird", 10)
 		output := buf.String()
 		dataIdx := strings.IndexByte(output, ' ')
-		assert.Equal(t, "[INFO ] with_test: root_test: a=1 b=2 c=3 bird=10\n", output[dataIdx+1:])
+		assert.Equal(t, "[INFO]  with_test: root_test: a=1 b=2 c=3 bird=10\n", output[dataIdx+1:])
 
 		buf.Reset()
 
 		derived.Info("derived_test")
 		output = buf.String()
 		dataIdx = strings.IndexByte(output, ' ')
-		assert.Equal(t, "[INFO ] with_test: derived_test: a=1 b=2 c=3 cat=30\n", output[dataIdx+1:])
+		assert.Equal(t, "[INFO]  with_test: derived_test: a=1 b=2 c=3 cat=30\n", output[dataIdx+1:])
 	})
 
 	t.Run("use with and log and change levels", func(t *testing.T) {
@@ -268,14 +268,14 @@ func TestLogger(t *testing.T) {
 		rootLogger.Info("root_test", "bird", 10)
 		output = buf.String()
 		dataIdx := strings.IndexByte(output, ' ')
-		assert.Equal(t, "[INFO ] with_test: root_test: a=1 b=2 c=3 bird=10\n", output[dataIdx+1:])
+		assert.Equal(t, "[INFO]  with_test: root_test: a=1 b=2 c=3 bird=10\n", output[dataIdx+1:])
 
 		buf.Reset()
 
 		derived.Info("derived_test")
 		output = buf.String()
 		dataIdx = strings.IndexByte(output, ' ')
-		assert.Equal(t, "[INFO ] with_test: derived_test: a=1 b=2 c=3 cat=30\n", output[dataIdx+1:])
+		assert.Equal(t, "[INFO]  with_test: derived_test: a=1 b=2 c=3 cat=30\n", output[dataIdx+1:])
 	})
 
 	t.Run("supports Printf style expansions when requested", func(t *testing.T) {
@@ -295,7 +295,7 @@ func TestLogger(t *testing.T) {
 		// ts := str[:dataIdx]
 		rest := str[dataIdx+1:]
 
-		assert.Equal(t, "[INFO ] test: this is test: production=\"12 beans/day\"\n", rest)
+		assert.Equal(t, "[INFO]  test: this is test: production=\"12 beans/day\"\n", rest)
 	})
 }
 


### PR DESCRIPTION
I understand the desire to have things aligned vertically, but adding the space inside the bracket makes grepping challenging. I moved the space outside the bracket, which will give the same behavior, but also look less weird (in my humble opinion).