### PR TITLE
[#11] Expose a configurable mutex for shared writers

### DIFF
--- a/int.go
+++ b/int.go
@@ -40,8 +40,13 @@ func New(opts *LoggerOptions) Logger {
 		level = DefaultLevel
 	}
 
+	mtx := opts.Mutex
+	if mtx == nil {
+		mtx = new(sync.Mutex)
+	}
+
 	return &intLogger{
-		m:      new(sync.Mutex),
+		m:      mtx,
 		json:   opts.JSONFormat,
 		caller: opts.IncludeLocation,
 		name:   opts.Name,

--- a/log.go
+++ b/log.go
@@ -5,6 +5,7 @@ import (
 	"log"
 	"os"
 	"strings"
+	"sync"
 )
 
 var (
@@ -129,6 +130,9 @@ type LoggerOptions struct {
 
 	// Where to write the logs to. Defaults to os.Stdout if nil
 	Output io.Writer
+
+	// An optional mutex pointer in case Output is shared
+	Mutex *sync.Mutex
 
 	// Control if the output should be in JSON.
 	JSONFormat bool


### PR DESCRIPTION
This is a proposed fix for #11 

In the event that your project does _not_ use hclog, however you wish to generate an hclog logger for a particular subsystem, it is useful to share a writer. This change exposes a configurable mutex to go along with the configured writer. If not set, hclog will generate and consume its own mutex.

One other option is to allow hclog to take in a stdlib logger and wrap around it, kicking back an hclog logger, however the output would then be subject to the formatting of the original logger, and would result in a much larger patch. I'm happy to take this route, however, if it makes more sense.