### PR TITLE
add JSONList option to logger

### DIFF
--- a/log.go
+++ b/log.go
@@ -149,6 +149,9 @@ type LoggerOptions struct {
 	// Control if the output should be in JSON.
 	JSONFormat bool
 
+	// Control if the JSONFormat should output lists instead of overriding previous values
+	JSONList bool
+
 	// Include file and line information in each log line
 	IncludeLocation bool
 

--- a/log.go
+++ b/log.go
@@ -152,6 +152,9 @@ type LoggerOptions struct {
 	// Control if the JSONFormat should output lists instead of overriding previous values
 	JSONList bool
 
+	// Control if the JSONFormat should promote single values to lists instead of overriding previous values
+	JSONListPromote bool
+
 	// Include file and line information in each log line
 	IncludeLocation bool
 

--- a/logger_test.go
+++ b/logger_test.go
@@ -279,6 +279,29 @@ func TestLogger_JSON(t *testing.T) {
 		assert.Equal(t, []interface{}{"testing is fun"}, raw["why"])
 	})
 
+	t.Run("json list promoting", func(t *testing.T) {
+		var buf bytes.Buffer
+		logger := New(&LoggerOptions{
+			Name:            "test",
+			Output:          &buf,
+			JSONFormat:      true,
+			JSONListPromote: true,
+		})
+
+		logger.Info("this is test", "who", "programmer", "why", "testing is fun", "who", "user")
+
+		b := buf.Bytes()
+
+		var raw map[string]interface{}
+		if err := json.Unmarshal(b, &raw); err != nil {
+			t.Fatal(err)
+		}
+
+		assert.Equal(t, "this is test", raw["@message"])
+		assert.Equal(t, []interface{}{"programmer", "user"}, raw["who"])
+		assert.Equal(t, "testing is fun", raw["why"])
+	})
+
 	t.Run("json formatting with", func(t *testing.T) {
 		var buf bytes.Buffer
 		logger := New(&LoggerOptions{

--- a/logger_test.go
+++ b/logger_test.go
@@ -256,6 +256,29 @@ func TestLogger_JSON(t *testing.T) {
 		assert.Equal(t, "testing is fun", raw["why"])
 	})
 
+	t.Run("json list formatting", func(t *testing.T) {
+		var buf bytes.Buffer
+		logger := New(&LoggerOptions{
+			Name:       "test",
+			Output:     &buf,
+			JSONFormat: true,
+			JSONList:   true,
+		})
+
+		logger.Info("this is test", "who", "programmer", "why", "testing is fun")
+
+		b := buf.Bytes()
+
+		var raw map[string]interface{}
+		if err := json.Unmarshal(b, &raw); err != nil {
+			t.Fatal(err)
+		}
+
+		assert.Equal(t, "this is test", raw["@message"])
+		assert.Equal(t, []interface{}{"programmer"}, raw["who"])
+		assert.Equal(t, []interface{}{"testing is fun"}, raw["why"])
+	})
+
 	t.Run("json formatting with", func(t *testing.T) {
 		var buf bytes.Buffer
 		logger := New(&LoggerOptions{

--- a/nulllogger.go
+++ b/nulllogger.go
@@ -1,8 +1,8 @@
 package hclog
 
 import (
-	"log"
 	"io/ioutil"
+	"log"
 )
 
 // NewNullLogger instantiates a Logger for which all calls


### PR DESCRIPTION
Allows `JSONList` for JSON formatter allows retaining multiple values for same key just like standard formatter does.