### PR TITLE
Expose Writer to allow for configuring standard logger

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,6 +128,21 @@ stdLogger.Printf("[DEBUG] %+v", stdLogger)
 ... [DEBUG] my-app: &{mu:{state:0 sema:0} prefix: flag:0 out:0xc42000a0a0 buf:[]}
 ```
 
+Alternatively, you may configure the system-wide logger:
+
+```go
+// log the standard logger from 'import "log"'
+log.SetOutput(appLogger.Writer(&hclog.StandardLoggerOptions{InferLevels: true}))
+log.SetPrefix("")
+log.SetFlags(0)
+
+log.Printf("[DEBUG] %d", 42)
+```
+
+```text
+... [DEBUG] my-app: 42
+```
+
 Notice that if `appLogger` is initialized with the `INFO` log level _and_ you
 specify `InferLevels: true`, you will not see any output here. You must change
 `appLogger` to `DEBUG` to see output. See the docs for more information.

--- a/int.go
+++ b/int.go
@@ -6,6 +6,7 @@ import (
 	"encoding"
 	"encoding/json"
 	"fmt"
+	"io"
 	"log"
 	"os"
 	"reflect"
@@ -503,5 +504,9 @@ func (z *intLogger) StandardLogger(opts *StandardLoggerOptions) *log.Logger {
 		opts = &StandardLoggerOptions{}
 	}
 
-	return log.New(&stdlogAdapter{z, opts.InferLevels}, "", 0)
+	return log.New(z.StandardWriter(opts), "", 0)
+}
+
+func (z *intLogger) StandardWriter(opts *StandardLoggerOptions) io.Writer {
+	return &stdlogAdapter{z, opts.InferLevels}
 }

--- a/log.go
+++ b/log.go
@@ -127,6 +127,9 @@ type Logger interface {
 
 	// Return a value that conforms to the stdlib log.Logger interface
 	StandardLogger(opts *StandardLoggerOptions) *log.Logger
+
+	// Return a value that conforms to io.Writer, which can be passed into log.SetOutput()
+	StandardWriter(opts *StandardLoggerOptions) io.Writer
 }
 
 type StandardLoggerOptions struct {

--- a/nulllogger.go
+++ b/nulllogger.go
@@ -1,6 +1,7 @@
 package hclog
 
 import (
+    "io"
 	"io/ioutil"
 	"log"
 )
@@ -43,5 +44,9 @@ func (l *nullLogger) ResetNamed(name string) Logger { return l }
 func (l *nullLogger) SetLevel(level Level) {}
 
 func (l *nullLogger) StandardLogger(opts *StandardLoggerOptions) *log.Logger {
-	return log.New(ioutil.Discard, "", log.LstdFlags)
+	return log.New(l.StandardWriter(opts), "", log.LstdFlags)
+}
+
+func (l *nullLogger) StandardWriter(opts *StandardLoggerOptions) io.Writer {
+    return ioutil.Discard
 }


### PR DESCRIPTION
This makes it possible to reconfigure the global logger, particularly useful when other libraries already use it.  I added an example to the end of the readme.