### PR TITLE
Fix comments to silence linters

### DIFF
--- a/global.go
+++ b/global.go
@@ -8,16 +8,16 @@ var (
 	protect sync.Once
 	def     Logger
 
-	// The options used to create the Default logger. These are
-	// read only when the Default logger is created, so set them
-	// as soon as the process starts.
+	// DefaultOptions is used to create the Default logger. These are read
+	// only when the Default logger is created, so set them as soon as the
+	// process starts.
 	DefaultOptions = &LoggerOptions{
 		Level:  DefaultLevel,
 		Output: DefaultOutput,
 	}
 )
 
-// Return a logger that is held globally. This can be a good starting
+// Default returns a globally held logger. This can be a good starting
 // place, and then you can use .With() and .Name() to create sub-loggers
 // to be used in more specific contexts.
 func Default() Logger {
@@ -28,7 +28,7 @@ func Default() Logger {
 	return def
 }
 
-// A short alias for Default()
+// L is a short alias for Default().
 func L() Logger {
 	return Default()
 }

--- a/intlogger.go
+++ b/intlogger.go
@@ -19,6 +19,10 @@ import (
 	"time"
 )
 
+// TimeFormat to use for logging. This is a version of RFC3339 that contains
+// contains millisecond precision
+const TimeFormat = "2006-01-02T15:04:05.000Z0700"
+
 var (
 	_levelToBracket = map[Level]string{
 		Debug: "[DEBUG]",
@@ -29,7 +33,27 @@ var (
 	}
 )
 
-// Given the options (nil for defaults), create a new Logger
+// Make sure that intLogger is a Logger
+var _ Logger = &intLogger{}
+
+// intLogger is an internal logger implementation. Internal in that it is
+// defined entirely by this package.
+type intLogger struct {
+	json       bool
+	caller     bool
+	name       string
+	timeFormat string
+
+	// This is a pointer so that it's shared by any derived loggers, since
+	// those derived loggers share the bufio.Writer as well.
+	mutex  *sync.Mutex
+	writer *bufio.Writer
+	level  *int32
+
+	implied []interface{}
+}
+
+// New returns a configured logger.
 func New(opts *LoggerOptions) Logger {
 	if opts == nil {
 		opts = &LoggerOptions{}
@@ -45,70 +69,49 @@ func New(opts *LoggerOptions) Logger {
 		level = DefaultLevel
 	}
 
-	mtx := opts.Mutex
-	if mtx == nil {
-		mtx = new(sync.Mutex)
+	mutex := opts.Mutex
+	if mutex == nil {
+		mutex = new(sync.Mutex)
 	}
 
-	ret := &intLogger{
-		m:          mtx,
+	l := &intLogger{
 		json:       opts.JSONFormat,
 		caller:     opts.IncludeLocation,
 		name:       opts.Name,
 		timeFormat: TimeFormat,
-		w:          bufio.NewWriter(output),
+		mutex:      mutex,
+		writer:     bufio.NewWriter(output),
 		level:      new(int32),
 	}
+
 	if opts.TimeFormat != "" {
-		ret.timeFormat = opts.TimeFormat
+		l.timeFormat = opts.TimeFormat
 	}
-	atomic.StoreInt32(ret.level, int32(level))
-	return ret
+
+	atomic.StoreInt32(l.level, int32(level))
+
+	return l
 }
-
-// The internal logger implementation. Internal in that it is defined entirely
-// by this package.
-type intLogger struct {
-	json       bool
-	caller     bool
-	name       string
-	timeFormat string
-
-	// this is a pointer so that it's shared by any derived loggers, since
-	// those derived loggers share the bufio.Writer as well.
-	m     *sync.Mutex
-	w     *bufio.Writer
-	level *int32
-
-	implied []interface{}
-}
-
-// Make sure that intLogger is a Logger
-var _ Logger = &intLogger{}
-
-// The time format to use for logging. This is a version of RFC3339 that
-// contains millisecond precision
-const TimeFormat = "2006-01-02T15:04:05.000Z0700"
 
 // Log a message and a set of key/value pairs if the given level is at
 // or more severe that the threshold configured in the Logger.
-func (z *intLogger) Log(level Level, msg string, args ...interface{}) {
-	if level < Level(atomic.LoadInt32(z.level)) {
+func (l *intLogger) Log(level Level, msg string, args ...interface{}) {
+	if level < Level(atomic.LoadInt32(l.level)) {
 		return
 	}
 
 	t := time.Now()
 
-	z.m.Lock()
-	defer z.m.Unlock()
+	l.mutex.Lock()
+	defer l.mutex.Unlock()
 
-	if z.json {
-		z.logJson(t, level, msg, args...)
+	if l.json {
+		l.logJSON(t, level, msg, args...)
 	} else {
-		z.log(t, level, msg, args...)
+		l.log(t, level, msg, args...)
 	}
 
-	z.w.Flush()
+	l.writer.Flush()
 }
 
 // Cleanup a path by returning the last 2 segments of the path only.
@@ -124,10 +127,8 @@ func trimCallerPath(path string) string {
 	// and https://github.com/golang/go/issues/18151
 	//
 	// for discussion on the issue on Go side.
-	//
 
 	// Find the last separator.
-	//
 	idx := strings.LastIndexByte(path, '/')
 	if idx == -1 {
 		return path
@@ -143,37 +144,37 @@ func trimCallerPath(path string) string {
 }
 
 // Non-JSON logging format function
-func (z *intLogger) log(t time.Time, level Level, msg string, args ...interface{}) {
-	z.w.WriteString(t.Format(z.timeFormat))
-	z.w.WriteByte(' ')
+func (l *intLogger) log(t time.Time, level Level, msg string, args ...interface{}) {
+	l.writer.WriteString(t.Format(l.timeFormat))
+	l.writer.WriteByte(' ')
 
 	s, ok := _levelToBracket[level]
 	if ok {
-		z.w.WriteString(s)
+		l.writer.WriteString(s)
 	} else {
-		z.w.WriteString("[?????]")
+		l.writer.WriteString("[?????]")
 	}
 
-	if z.caller {
+	if l.caller {
 		if _, file, line, ok := runtime.Caller(3); ok {
-			z.w.WriteByte(' ')
-			z.w.WriteString(trimCallerPath(file))
-			z.w.WriteByte(':')
-			z.w.WriteString(strconv.Itoa(line))
-			z.w.WriteByte(':')
+			l.writer.WriteByte(' ')
+			l.writer.WriteString(trimCallerPath(file))
+			l.writer.WriteByte(':')
+			l.writer.WriteString(strconv.Itoa(line))
+			l.writer.WriteByte(':')
 		}
 	}
 
-	z.w.WriteByte(' ')
+	l.writer.WriteByte(' ')
 
-	if z.name != "" {
-		z.w.WriteString(z.name)
-		z.w.WriteString(": ")
+	if l.name != "" {
+		l.writer.WriteString(l.name)
+		l.writer.WriteString(": ")
 	}
 
-	z.w.WriteString(msg)
+	l.writer.WriteString(msg)
 
-	args = append(z.implied, args...)
+	args = append(l.implied, args...)
 
 	var stacktrace CapturedStacktrace
 
@@ -188,7 +189,7 @@ func (z *intLogger) log(t time.Time, level Level, msg string, args ...interface{
 			}
 		}
 
-		z.w.WriteByte(':')
+		l.writer.WriteByte(':')
 
 	FOR:
 		for i := 0; i < len(args); i = i + 2 {
@@ -228,35 +229,35 @@ func (z *intLogger) log(t time.Time, level Level, msg string, args ...interface{
 			default:
 				v := reflect.ValueOf(st)
 				if v.Kind() == reflect.Slice {
-					val = z.renderSlice(v)
+					val = l.renderSlice(v)
 					raw = true
 				} else {
 					val = fmt.Sprintf("%v", st)
 				}
 			}
 
-			z.w.WriteByte(' ')
-			z.w.WriteString(args[i].(string))
-			z.w.WriteByte('=')
+			l.writer.WriteByte(' ')
+			l.writer.WriteString(args[i].(string))
+			l.writer.WriteByte('=')
 
 			if !raw && strings.ContainsAny(val, " \t\n\r") {
-				z.w.WriteByte('"')
-				z.w.WriteString(val)
-				z.w.WriteByte('"')
+				l.writer.WriteByte('"')
+				l.writer.WriteString(val)
+				l.writer.WriteByte('"')
 			} else {
-				z.w.WriteString(val)
+				l.writer.WriteString(val)
 			}
 		}
 	}
 
-	z.w.WriteString("\n")
+	l.writer.WriteString("\n")
 
 	if stacktrace != "" {
-		z.w.WriteString(string(stacktrace))
+		l.writer.WriteString(string(stacktrace))
 	}
 }
 
-func (z *intLogger) renderSlice(v reflect.Value) string {
+func (l *intLogger) renderSlice(v reflect.Value) string {
 	var buf bytes.Buffer
 
 	buf.WriteRune('[')
@@ -296,7 +297,7 @@ func (z *intLogger) renderSlice(v reflect.Value) string {
 }
 
 // JSON logging function
-func (z *intLogger) logJson(t time.Time, level Level, msg string, args ...interface{}) {
+func (l *intLogger) logJSON(t time.Time, level Level, msg string, args ...interface{}) {
 	vals := map[string]interface{}{
 		"@message":   msg,
 		"@timestamp": t.Format("2006-01-02T15:04:05.000000Z07:00"),
@@ -320,17 +321,17 @@ func (z *intLogger) logJson(t time.Time, level Level, msg string, args ...interf
 
 	vals["@level"] = levelStr
 
-	if z.name != "" {
-		vals["@module"] = z.name
+	if l.name != "" {
+		vals["@module"] = l.name
 	}
 
-	if z.caller {
+	if l.caller {
 		if _, file, line, ok := runtime.Caller(3); ok {
 			vals["@caller"] = fmt.Sprintf("%s:%d", file, line)
 		}
 	}
 
-	args = append(z.implied, args...)
+	args = append(l.implied, args...)
 
 	if args != nil && len(args) > 0 {
 		if len(args)%2 != 0 {
@@ -368,80 +369,80 @@ func (z *intLogger) logJson(t time.Time, level Level, msg string, args ...interf
 		}
 	}
 
-	err := json.NewEncoder(z.w).Encode(vals)
+	err := json.NewEncoder(l.writer).Encode(vals)
 	if err != nil {
 		panic(err)
 	}
 }
 
 // Emit the message and args at DEBUG level
-func (z *intLogger) Debug(msg string, args ...interface{}) {
-	z.Log(Debug, msg, args...)
+func (l *intLogger) Debug(msg string, args ...interface{}) {
+	l.Log(Debug, msg, args...)
 }
 
 // Emit the message and args at TRACE level
-func (z *intLogger) Trace(msg string, args ...interface{}) {
-	z.Log(Trace, msg, args...)
+func (l *intLogger) Trace(msg string, args ...interface{}) {
+	l.Log(Trace, msg, args...)
 }
 
 // Emit the message and args at INFO level
-func (z *intLogger) Info(msg string, args ...interface{}) {
-	z.Log(Info, msg, args...)
+func (l *intLogger) Info(msg string, args ...interface{}) {
+	l.Log(Info, msg, args...)
 }
 
 // Emit the message and args at WARN level
-func (z *intLogger) Warn(msg string, args ...interface{}) {
-	z.Log(Warn, msg, args...)
+func (l *intLogger) Warn(msg string, args ...interface{}) {
+	l.Log(Warn, msg, args...)
 }
 
 // Emit the message and args at ERROR level
-func (z *intLogger) Error(msg string, args ...interface{}) {
-	z.Log(Error, msg, args...)
+func (l *intLogger) Error(msg string, args ...interface{}) {
+	l.Log(Error, msg, args...)
 }
 
 // Indicate that the logger would emit TRACE level logs
-func (z *intLogger) IsTrace() bool {
-	return Level(atomic.LoadInt32(z.level)) == Trace
+func (l *intLogger) IsTrace() bool {
+	return Level(atomic.LoadInt32(l.level)) == Trace
 }
 
 // Indicate that the logger would emit DEBUG level logs
-func (z *intLogger) IsDebug() bool {
-	return Level(atomic.LoadInt32(z.level)) <= Debug
+func (l *intLogger) IsDebug() bool {
+	return Level(atomic.LoadInt32(l.level)) <= Debug
 }
 
 // Indicate that the logger would emit INFO level logs
-func (z *intLogger) IsInfo() bool {
-	return Level(atomic.LoadInt32(z.level)) <= Info
+func (l *intLogger) IsInfo() bool {
+	return Level(atomic.LoadInt32(l.level)) <= Info
 }
 
 // Indicate that the logger would emit WARN level logs
-func (z *intLogger) IsWarn() bool {
-	return Level(atomic.LoadInt32(z.level)) <= Warn
+func (l *intLogger) IsWarn() bool {
+	return Level(atomic.LoadInt32(l.level)) <= Warn
 }
 
 // Indicate that the logger would emit ERROR level logs
-func (z *intLogger) IsError() bool {
-	return Level(atomic.LoadInt32(z.level)) <= Error
+func (l *intLogger) IsError() bool {
+	return Level(atomic.LoadInt32(l.level)) <= Error
 }
 
 // Return a sub-Logger for which every emitted log message will contain
 // the given key/value pairs. This is used to create a context specific
 // Logger.
-func (z *intLogger) With(args ...interface{}) Logger {
+func (l *intLogger) With(args ...interface{}) Logger {
 	if len(args)%2 != 0 {
 		panic("With() call requires paired arguments")
 	}
 
-	var nz intLogger = *z
+	sl := *l
 
-	result := make(map[string]interface{}, len(z.implied)+len(args))
-	keys := make([]string, 0, len(z.implied)+len(args))
+	result := make(map[string]interface{}, len(l.implied)+len(args))
+	keys := make([]string, 0, len(l.implied)+len(args))
 
 	// Read existing args, store map and key for consistent sorting
-	for i := 0; i < len(z.implied); i += 2 {
-		key := z.implied[i].(string)
+	for i := 0; i < len(l.implied); i += 2 {
+		key := l.implied[i].(string)
 		keys = append(keys, key)
-		result[key] = z.implied[i+1]
+		result[key] = l.implied[i+1]
 	}
 	// Read new args, store map and key for consistent sorting
 	for i := 0; i < len(args); i += 2 {
@@ -456,57 +457,57 @@ func (z *intLogger) With(args ...interface{}) Logger {
 	// Sort keys to be consistent
 	sort.Strings(keys)
 
-	nz.implied = make([]interface{}, 0, len(z.implied)+len(args))
+	sl.implied = make([]interface{}, 0, len(l.implied)+len(args))
 	for _, k := range keys {
-		nz.implied = append(nz.implied, k)
-		nz.implied = append(nz.implied, result[k])
+		sl.implied = append(sl.implied, k)
+		sl.implied = append(sl.implied, result[k])
 	}
 
-	return &nz
+	return &sl
 }
 
 // Create a new sub-Logger that a name decending from the current name.
 // This is used to create a subsystem specific Logger.
-func (z *intLogger) Named(name string) Logger {
-	var nz intLogger = *z
+func (l *intLogger) Named(name string) Logger {
+	sl := *l
 
-	if nz.name != "" {
-		nz.name = nz.name + "." + name
+	if sl.name != "" {
+		sl.name = sl.name + "." + name
 	} else {
-		nz.name = name
+		sl.name = name
 	}
 
-	return &nz
+	return &sl
 }
 
 // Create a new sub-Logger with an explicit name. This ignores the current
 // name. This is used to create a standalone logger that doesn't fall
 // within the normal hierarchy.
-func (z *intLogger) ResetNamed(name string) Logger {
-	var nz intLogger = *z
+func (l *intLogger) ResetNamed(name string) Logger {
+	sl := *l
 
-	nz.name = name
+	sl.name = name
 
-	return &nz
+	return &sl
 }
 
 // Update the logging level on-the-fly. This will affect all subloggers as
 // well.
-func (z *intLogger) SetLevel(level Level) {
-	atomic.StoreInt32(z.level, int32(level))
+func (l *intLogger) SetLevel(level Level) {
+	atomic.StoreInt32(l.level, int32(level))
 }
 
 // Create a *log.Logger that will send it's data through this Logger. This
 // allows packages that expect to be using the standard library log to actually
 // use this logger.
-func (z *intLogger) StandardLogger(opts *StandardLoggerOptions) *log.Logger {
+func (l *intLogger) StandardLogger(opts *StandardLoggerOptions) *log.Logger {
 	if opts == nil {
 		opts = &StandardLoggerOptions{}
 	}
 
-	return log.New(z.StandardWriter(opts), "", 0)
+	return log.New(l.StandardWriter(opts), "", 0)
 }
 
-func (z *intLogger) StandardWriter(opts *StandardLoggerOptions) io.Writer {
-	return &stdlogAdapter{z, opts.InferLevels}
+func (l *intLogger) StandardWriter(opts *StandardLoggerOptions) io.Writer {
+	return &stdlogAdapter{l, opts.InferLevels}
 }

--- a/logger.go
+++ b/logger.go
@@ -9,38 +9,42 @@ import (
 )
 
 var (
+	//DefaultOutput is used as the default log output.
 	DefaultOutput = os.Stderr
-	DefaultLevel  = Info
+
+	// DefaultLevel is used as the default log level.
+	DefaultLevel = Info
 )
 
+// Level represents a log level.
 type Level int32
 
 const (
-	// This is a special level used to indicate that no level has been
+	// NoLevel is a special level used to indicate that no level has been
 	// set and allow for a default to be used.
 	NoLevel Level = 0
 
-	// The most verbose level. Intended to be used for the tracing of actions
-	// in code, such as function enters/exits, etc.
+	// Trace is the most verbose level. Intended to be used for the tracing
+	// of actions in code, such as function enters/exits, etc.
 	Trace Level = 1
 
-	// For programmer lowlevel analysis.
+	// Debug information for programmer lowlevel analysis.
 	Debug Level = 2
 
-	// For information about steady state operations.
+	// Info information about steady state operations.
 	Info Level = 3
 
-	// For information about rare but handled events.
+	// Warn information about rare but handled events.
 	Warn Level = 4
 
-	// For information about unrecoverable events.
+	// Error information about unrecoverable events.
 	Error Level = 5
 )
 
-// When processing a value of this type, the logger automatically treats the first
-// argument as a Printf formatting string and passes the rest as the values to be
-// formatted. For example: L.Info(Fmt{"%d beans/day", beans}). This is a simple
-// convience type for when formatting is required.
+// Format is a simple convience type for when formatting is required. When
+// processing a value of this type, the logger automatically treats the first
+// argument as a Printf formatting string and passes the rest as the values
+// to be formatted. For example: L.Info(Fmt{"%d beans/day", beans}).
 type Format []interface{}
 
 // Fmt returns a Format type. This is a convience function for creating a Format
@@ -53,7 +57,7 @@ func Fmt(str string, args ...interface{}) Format {
 // the level string is invalid. This facilitates setting the log level via
 // config or environment variable by name in a predictable way.
 func LevelFromString(levelStr string) Level {
-	// We don't care about case. Accept "INFO" or "info"
+	// We don't care about case. Accept both "INFO" and "info".
 	levelStr = strings.ToLower(strings.TrimSpace(levelStr))
 	switch levelStr {
 	case "trace":
@@ -71,7 +75,7 @@ func LevelFromString(levelStr string) Level {
 	}
 }
 
-// The main Logger interface. All code should code against this interface only.
+// Logger describes the interface that must be implemeted by all loggers.
 type Logger interface {
 	// Args are alternating key, val pairs
 	// keys must be strings
@@ -132,6 +136,7 @@ type Logger interface {
 	StandardWriter(opts *StandardLoggerOptions) io.Writer
 }
 
+// StandardLoggerOptions can be used to configure a new standard logger.
 type StandardLoggerOptions struct {
 	// Indicate that some minimal parsing should be done on strings to try
 	// and detect their level and re-emit them.
@@ -140,6 +145,7 @@ type StandardLoggerOptions struct {
 	InferLevels bool
 }
 
+// LoggerOptions can be used to configure a new logger.
 type LoggerOptions struct {
 	// Name of the subsystem to prefix logs with
 	Name string

--- a/nulllogger.go
+++ b/nulllogger.go
@@ -1,7 +1,7 @@
 package hclog
 
 import (
-    "io"
+	"io"
 	"io/ioutil"
 	"log"
 )
@@ -48,5 +48,5 @@ func (l *nullLogger) StandardLogger(opts *StandardLoggerOptions) *log.Logger {
 }
 
 func (l *nullLogger) StandardWriter(opts *StandardLoggerOptions) io.Writer {
-    return ioutil.Discard
+	return ioutil.Discard
 }

--- a/nulllogger_test.go
+++ b/nulllogger_test.go
@@ -2,6 +2,7 @@ package hclog
 
 import (
 	"testing"
+
 	"github.com/stretchr/testify/assert"
 )
 

--- a/stacktrace.go
+++ b/stacktrace.go
@@ -40,12 +40,13 @@ var (
 	}
 )
 
-// A stacktrace gathered by a previous call to log.Stacktrace. If passed
-// to a logging function, the stacktrace will be appended.
+// CapturedStacktrace represents a stacktrace captured by a previous call
+// to log.Stacktrace. If passed to a logging function, the stacktrace
+// will be appended.
 type CapturedStacktrace string
 
-// Gather a stacktrace of the current goroutine and return it to be passed
-// to a logging function.
+// Stacktrace captures a stacktrace of the current goroutine and returns
+// it to be passed to a logging function.
 func Stacktrace() CapturedStacktrace {
 	return CapturedStacktrace(takeStacktrace())
 }

--- a/stdlog.go
+++ b/stdlog.go
@@ -9,12 +9,12 @@ import (
 // and back into our Logger. This is basically the only way to
 // build upon *log.Logger.
 type stdlogAdapter struct {
-	hl          Logger
+	log         Logger
 	inferLevels bool
 }
 
 // Take the data, infer the levels if configured, and send it through
-// a regular Logger
+// a regular Logger.
 func (s *stdlogAdapter) Write(data []byte) (int, error) {
 	str := string(bytes.TrimRight(data, " \t\n"))
 
@@ -22,26 +22,26 @@ func (s *stdlogAdapter) Write(data []byte) (int, error) {
 		level, str := s.pickLevel(str)
 		switch level {
 		case Trace:
-			s.hl.Trace(str)
+			s.log.Trace(str)
 		case Debug:
-			s.hl.Debug(str)
+			s.log.Debug(str)
 		case Info:
-			s.hl.Info(str)
+			s.log.Info(str)
 		case Warn:
-			s.hl.Warn(str)
+			s.log.Warn(str)
 		case Error:
-			s.hl.Error(str)
+			s.log.Error(str)
 		default:
-			s.hl.Info(str)
+			s.log.Info(str)
 		}
 	} else {
-		s.hl.Info(str)
+		s.log.Info(str)
 	}
 
 	return len(data), nil
 }
 
-// Detect, based on conventions, what log level this is
+// Detect, based on conventions, what log level this is.
 func (s *stdlogAdapter) pickLevel(str string) (Level, string) {
 	switch {
 	case strings.HasPrefix(str, "[DEBUG]"):


### PR DESCRIPTION
Probably 95% of this commit only updates comments so my linters don’t complain sbout them anymore.

The other 5% does some very, very mild refactoring of the internal logger to make it easier to read the code.

Functionally it doesn’t change anything and it (of course) doesn’t change the public API!