### PR TITLE
[stdlog] Reuse dispatching logic to avoid duplication.

### DIFF
--- a/stdlog.go
+++ b/stdlog.go
@@ -25,41 +25,32 @@ func (s *stdlogAdapter) Write(data []byte) (int, error) {
 		_, str := s.pickLevel(str)
 
 		// Log at the forced level
-		switch s.forceLevel {
-		case Trace:
-			s.log.Trace(str)
-		case Debug:
-			s.log.Debug(str)
-		case Info:
-			s.log.Info(str)
-		case Warn:
-			s.log.Warn(str)
-		case Error:
-			s.log.Error(str)
-		default:
-			s.log.Info(str)
-		}
+		s.dispatch(str, s.forceLevel)
 	} else if s.inferLevels {
 		level, str := s.pickLevel(str)
-		switch level {
-		case Trace:
-			s.log.Trace(str)
-		case Debug:
-			s.log.Debug(str)
-		case Info:
-			s.log.Info(str)
-		case Warn:
-			s.log.Warn(str)
-		case Error:
-			s.log.Error(str)
-		default:
-			s.log.Info(str)
-		}
+		s.dispatch(str, level)
 	} else {
 		s.log.Info(str)
 	}
 
 	return len(data), nil
+}
+
+func (s *stdlogAdapter) dispatch(str string, level Level) {
+	switch level {
+	case Trace:
+		s.log.Trace(str)
+	case Debug:
+		s.log.Debug(str)
+	case Info:
+		s.log.Info(str)
+	case Warn:
+		s.log.Warn(str)
+	case Error:
+		s.log.Error(str)
+	default:
+		s.log.Info(str)
+	}
 }
 
 // Detect, based on conventions, what log level this is.

--- a/stdlog_test.go
+++ b/stdlog_test.go
@@ -109,6 +109,20 @@ func TestStdlogAdapter_ForceLevel(t *testing.T) {
 			write:      "this is a test",
 			expect:     "[INFO]  test: this is a test\n",
 		},
+		{
+			name:        "infer debug",
+			forceLevel:  NoLevel,
+			inferLevels: true,
+			write:       "[DEBUG] debug info",
+			expect:      "[DEBUG] test: debug info\n",
+		},
+		{
+			name:        "info is used if not forced and cannot infer",
+			forceLevel:  NoLevel,
+			inferLevels: false,
+			write:       "some message",
+			expect:      "[INFO]  test: some message\n",
+		},
 	}
 
 	for _, c := range cases {


### PR DESCRIPTION
Reduced duplication also results in better code coverage. Some branches
are still not covered, but it's a start.