### PR TITLE
Adds new MultiSinkLogger 

### DIFF
--- a/intlogger.go
+++ b/intlogger.go
@@ -141,7 +141,7 @@ func trimCallerPath(path string) string {
 
 // Non-JSON logging format function
 func (l *intLogger) log(t time.Time, level Level, msg string, args ...interface{}) {
-	line := logImpl(&logLine{
+	line := build(&logLine{
 		w:       l.writer,
 		t:       t,
 		tfmt:    l.timeFormat,
@@ -155,7 +155,7 @@ func (l *intLogger) log(t time.Time, level Level, msg string, args ...interface{
 
 // JSON logging function
 func (l *intLogger) logJSON(t time.Time, level Level, msg string, args ...interface{}) {
-	line := logJSONImpl(&logLine{
+	line := buildJSON(&logLine{
 		w:       l.writer,
 		t:       t,
 		tfmt:    l.timeFormat,

--- a/intlogger.go
+++ b/intlogger.go
@@ -99,8 +99,7 @@ func (l *intLogger) log(t time.Time, level Level, msg string, args ...interface{
 		caller:  l.caller,
 		implied: l.implied,
 	}
-	buf := ld.build(level, msg, args...)
-	l.writer.Write(buf.Bytes())
+	l.writer.Write(ld.build(level, msg, args...))
 }
 
 // JSON logging function
@@ -112,8 +111,7 @@ func (l *intLogger) logJSON(t time.Time, level Level, msg string, args ...interf
 		caller:  l.caller,
 		implied: l.implied,
 	}
-	buf := ld.buildJSON(level, msg, args...)
-	l.writer.Write(buf.Bytes())
+	l.writer.Write(ld.buildJSON(level, msg, args...))
 }
 
 // Emit the message and args at DEBUG level

--- a/intlogger.go
+++ b/intlogger.go
@@ -92,30 +92,28 @@ func (l *intLogger) Log(level Level, msg string, args ...interface{}) {
 
 // Non-JSON logging format function
 func (l *intLogger) log(t time.Time, level Level, msg string, args ...interface{}) {
-	line := build(&logLine{
-		w:       l.writer,
+	ld := &lineDetails{
 		t:       t,
 		tfmt:    l.timeFormat,
 		name:    l.name,
 		caller:  l.caller,
 		implied: l.implied,
-	}, level, msg, args...)
-
-	l.writer.Write(line.Bytes())
+	}
+	buf := ld.build(level, msg, args...)
+	l.writer.Write(buf.Bytes())
 }
 
 // JSON logging function
 func (l *intLogger) logJSON(t time.Time, level Level, msg string, args ...interface{}) {
-	line := buildJSON(&logLine{
-		w:       l.writer,
+	ld := &lineDetails{
 		t:       t,
 		tfmt:    l.timeFormat,
 		name:    l.name,
 		caller:  l.caller,
 		implied: l.implied,
-	}, level, msg, args...)
-
-	l.writer.Write(line.Bytes())
+	}
+	buf := ld.buildJSON(level, msg, args...)
+	l.writer.Write(buf.Bytes())
 }
 
 // Emit the message and args at DEBUG level

--- a/log.go
+++ b/log.go
@@ -57,7 +57,7 @@ func (ll *logLine) jsonMapEntry(t time.Time, level Level, msg string) map[string
 	return vals
 }
 
-func logJSONImpl(ll *logLine, level Level, msg string, args ...interface{}) bytes.Buffer {
+func buildJSON(ll *logLine, level Level, msg string, args ...interface{}) bytes.Buffer {
 	var line bytes.Buffer
 	vals := ll.jsonMapEntry(ll.t, level, msg)
 	args = append(ll.implied, args...)
@@ -110,7 +110,7 @@ func logJSONImpl(ll *logLine, level Level, msg string, args ...interface{}) byte
 	return line
 }
 
-func logImpl(ll *logLine, level Level, msg string, args ...interface{}) bytes.Buffer {
+func build(ll *logLine, level Level, msg string, args ...interface{}) bytes.Buffer {
 	var line bytes.Buffer
 
 	line.WriteString(ll.t.Format(ll.tfmt))

--- a/log.go
+++ b/log.go
@@ -1,0 +1,266 @@
+package hclog
+
+import (
+	"bytes"
+	"encoding"
+	"encoding/json"
+	"fmt"
+	"reflect"
+	"runtime"
+	"strconv"
+	"strings"
+	"time"
+)
+
+type logLine struct {
+	w       *writer
+	t       time.Time
+	tfmt    string
+	name    string
+	caller  bool
+	implied []interface{}
+}
+
+func (ll *logLine) jsonMapEntry(t time.Time, level Level, msg string) map[string]interface{} {
+	vals := map[string]interface{}{
+		"@message":   msg,
+		"@timestamp": t.Format("2006-01-02T15:04:05.000000Z07:00"),
+	}
+
+	var levelStr string
+	switch level {
+	case Error:
+		levelStr = "error"
+	case Warn:
+		levelStr = "warn"
+	case Info:
+		levelStr = "info"
+	case Debug:
+		levelStr = "debug"
+	case Trace:
+		levelStr = "trace"
+	default:
+		levelStr = "all"
+	}
+
+	vals["@level"] = levelStr
+
+	if ll.name != "" {
+		vals["@module"] = ll.name
+	}
+
+	if ll.caller {
+		if _, file, line, ok := runtime.Caller(5); ok {
+			vals["@caller"] = fmt.Sprintf("%s:%d", file, line)
+		}
+	}
+	return vals
+}
+
+func logJSONImpl(ll *logLine, level Level, msg string, args ...interface{}) bytes.Buffer {
+	var line bytes.Buffer
+	vals := ll.jsonMapEntry(ll.t, level, msg)
+	args = append(ll.implied, args...)
+
+	if args != nil && len(args) > 0 {
+		if len(args)%2 != 0 {
+			cs, ok := args[len(args)-1].(CapturedStacktrace)
+			if ok {
+				args = args[:len(args)-1]
+				vals["stacktrace"] = cs
+			} else {
+				args = append(args, "<unknown>")
+			}
+		}
+
+		for i := 0; i < len(args); i = i + 2 {
+			if _, ok := args[i].(string); !ok {
+				// As this is the logging function not much we can do here
+				// without injecting into logs...
+				continue
+			}
+			val := args[i+1]
+			switch sv := val.(type) {
+			case error:
+				// Check if val is of type error. If error type doesn't
+				// implement json.Marshaler or encoding.TextMarshaler
+				// then set val to err.Error() so that it gets marshaled
+				switch sv.(type) {
+				case json.Marshaler, encoding.TextMarshaler:
+				default:
+					val = sv.Error()
+				}
+			case Format:
+				val = fmt.Sprintf(sv[0].(string), sv[1:]...)
+			}
+
+			vals[args[i].(string)] = val
+		}
+	}
+	err := json.NewEncoder(&line).Encode(vals)
+	if err != nil {
+		if _, ok := err.(*json.UnsupportedTypeError); ok {
+			plainVal := ll.jsonMapEntry(ll.t, level, msg)
+			plainVal["@warn"] = errJsonUnsupportedTypeMsg
+
+			json.NewEncoder(&line).Encode(plainVal)
+		}
+	}
+
+	return line
+}
+
+func logImpl(ll *logLine, level Level, msg string, args ...interface{}) bytes.Buffer {
+	var line bytes.Buffer
+
+	line.WriteString(ll.t.Format(ll.tfmt))
+	line.WriteByte(' ')
+
+	s, ok := _levelToBracket[level]
+	if ok {
+		line.WriteString(s)
+	} else {
+		line.WriteString("[?????]")
+	}
+
+	if ll.caller {
+		if _, file, l, ok := runtime.Caller(4); ok {
+			line.WriteByte(' ')
+			line.WriteString(trimCallerPath(file))
+			line.WriteByte(':')
+			line.WriteString(strconv.Itoa(l))
+			line.WriteByte(':')
+		}
+	}
+
+	line.WriteByte(' ')
+
+	if ll.name != "" {
+		line.WriteString(ll.name)
+		line.WriteString(": ")
+	}
+
+	line.WriteString(msg)
+
+	args = append(ll.implied, args...)
+
+	var stacktrace CapturedStacktrace
+
+	if args != nil && len(args) > 0 {
+		if len(args)%2 != 0 {
+			cs, ok := args[len(args)-1].(CapturedStacktrace)
+			if ok {
+				args = args[:len(args)-1]
+				stacktrace = cs
+			} else {
+				args = append(args, "<unknown>")
+			}
+		}
+
+		line.WriteByte(':')
+	FOR:
+		for i := 0; i < len(args); i = i + 2 {
+			var (
+				val string
+				raw bool
+			)
+
+			switch st := args[i+1].(type) {
+			case string:
+				val = st
+			case int:
+				val = strconv.FormatInt(int64(st), 10)
+			case int64:
+				val = strconv.FormatInt(int64(st), 10)
+			case int32:
+				val = strconv.FormatInt(int64(st), 10)
+			case int16:
+				val = strconv.FormatInt(int64(st), 10)
+			case int8:
+				val = strconv.FormatInt(int64(st), 10)
+			case uint:
+				val = strconv.FormatUint(uint64(st), 10)
+			case uint64:
+				val = strconv.FormatUint(uint64(st), 10)
+			case uint32:
+				val = strconv.FormatUint(uint64(st), 10)
+			case uint16:
+				val = strconv.FormatUint(uint64(st), 10)
+			case uint8:
+				val = strconv.FormatUint(uint64(st), 10)
+			case CapturedStacktrace:
+				stacktrace = st
+				continue FOR
+			case Format:
+				val = fmt.Sprintf(st[0].(string), st[1:]...)
+			default:
+				v := reflect.ValueOf(st)
+				if v.Kind() == reflect.Slice {
+					val = renderSlice(v)
+					raw = true
+				} else {
+					val = fmt.Sprintf("%v", st)
+				}
+			}
+
+			line.WriteByte(' ')
+			line.WriteString(args[i].(string))
+			line.WriteByte('=')
+
+			if !raw && strings.ContainsAny(val, " \t\n\r") {
+				line.WriteByte('"')
+				line.WriteString(val)
+				line.WriteByte('"')
+			} else {
+				line.WriteString(val)
+			}
+		}
+	}
+	line.WriteString("\n")
+
+	if stacktrace != "" {
+		line.WriteString(string(stacktrace))
+	}
+
+	return line
+
+}
+
+func renderSlice(v reflect.Value) string {
+	var buf bytes.Buffer
+
+	buf.WriteRune('[')
+
+	for i := 0; i < v.Len(); i++ {
+		if i > 0 {
+			buf.WriteString(", ")
+		}
+
+		sv := v.Index(i)
+
+		var val string
+
+		switch sv.Kind() {
+		case reflect.String:
+			val = sv.String()
+		case reflect.Int, reflect.Int16, reflect.Int32, reflect.Int64:
+			val = strconv.FormatInt(sv.Int(), 10)
+		case reflect.Uint, reflect.Uint16, reflect.Uint32, reflect.Uint64:
+			val = strconv.FormatUint(sv.Uint(), 10)
+		default:
+			val = fmt.Sprintf("%v", sv.Interface())
+		}
+
+		if strings.ContainsAny(val, " \t\n\r") {
+			buf.WriteByte('"')
+			buf.WriteString(val)
+			buf.WriteByte('"')
+		} else {
+			buf.WriteString(val)
+		}
+	}
+
+	buf.WriteRune(']')
+
+	return buf.String()
+}

--- a/log.go
+++ b/log.go
@@ -37,7 +37,7 @@ type lineDetails struct {
 	implied []interface{}
 }
 
-func (l *lineDetails) build(level Level, msg string, args ...interface{}) bytes.Buffer {
+func (l *lineDetails) build(level Level, msg string, args ...interface{}) []byte {
 	var line bytes.Buffer
 
 	line.WriteString(l.t.Format(l.tfmt))
@@ -149,10 +149,10 @@ func (l *lineDetails) build(level Level, msg string, args ...interface{}) bytes.
 		line.WriteString(string(stacktrace))
 	}
 
-	return line
+	return line.Bytes()
 
 }
-func (l *lineDetails) buildJSON(level Level, msg string, args ...interface{}) bytes.Buffer {
+func (l *lineDetails) buildJSON(level Level, msg string, args ...interface{}) []byte {
 	var line bytes.Buffer
 	vals := l.jsonMapEntry(l.t, level, msg)
 	args = append(l.implied, args...)
@@ -202,7 +202,7 @@ func (l *lineDetails) buildJSON(level Level, msg string, args ...interface{}) by
 		}
 	}
 
-	return line
+	return line.Bytes()
 }
 
 func (l *lineDetails) jsonMapEntry(t time.Time, level Level, msg string) map[string]interface{} {

--- a/logger.go
+++ b/logger.go
@@ -145,6 +145,17 @@ type SinkOptions struct {
 type MultiSinkLogger interface {
 	Logger
 
+	// Create a logger that will prepend the name string on the front of all messages.
+	// This sets the name of the logger to the value directoly, unlike Named, which
+	// honor the current name as well. This also remains a MultiSinkLogger
+	ResetNamedMultiSink(name string) MultiSinkLogger
+
+	// Create a logger that will prepend the name string on the front of all messages.
+	// If the logger already has a name, the new value will be appended to the current
+	// name. That way, a major subsystem can use this to decorate all it's own logs
+	// without losing context.
+	NamedMultiSink(name string) MultiSinkLogger
+
 	RegisterSink(*Sink)
 	DeregisterSink(*Sink)
 }

--- a/logger.go
+++ b/logger.go
@@ -136,6 +136,21 @@ type Logger interface {
 	StandardWriter(opts *StandardLoggerOptions) io.Writer
 }
 
+type SinkOptions struct {
+	Output     io.Writer
+	Level      Level
+	JSONFormat bool
+}
+
+type MultiSinkLogger interface {
+	Logger
+
+	Level() Level
+
+	RegisterSink(*Sink)
+	DeregisterSink(*Sink)
+}
+
 // StandardLoggerOptions can be used to configure a new standard logger.
 type StandardLoggerOptions struct {
 	// Indicate that some minimal parsing should be done on strings to try

--- a/logger.go
+++ b/logger.go
@@ -145,8 +145,6 @@ type SinkOptions struct {
 type MultiSinkLogger interface {
 	Logger
 
-	Level() Level
-
 	RegisterSink(*Sink)
 	DeregisterSink(*Sink)
 }

--- a/logger_test.go
+++ b/logger_test.go
@@ -689,7 +689,6 @@ func TestMultiSinkLogger(t *testing.T) {
 		rest := str[dataIdx+1:]
 
 		assert.Equal(t, "[DEBUG] test.sublogger: test sublogger\n", rest)
-
 	})
 }
 

--- a/logger_test.go
+++ b/logger_test.go
@@ -606,6 +606,65 @@ func TestLogger_JSON(t *testing.T) {
 	})
 }
 
+func TestMultiSinkLogger(t *testing.T) {
+	t.Run("Sends output to both sink and logger", func(t *testing.T) {
+		var logBuf bytes.Buffer
+		var sinkBuf bytes.Buffer
+
+		logger := NewMultiSink(&LoggerOptions{
+			Level:  Info,
+			Name:   "test",
+			Output: &logBuf,
+		})
+
+		sink := NewSink(&SinkOptions{
+			Level:  Info,
+			Output: &sinkBuf,
+		})
+		logger.RegisterSink(sink)
+
+		logger.Info("test info log", "who", "programmer")
+
+		str := logBuf.String()
+		dataIdx := strings.IndexByte(str, ' ')
+		rest := str[dataIdx+1:]
+		assert.Equal(t, "[INFO]  test: test info log: who=programmer\n", rest)
+
+		str = sinkBuf.String()
+		dataIdx = strings.IndexByte(str, ' ')
+		rest = str[dataIdx+1:]
+		assert.Equal(t, "[INFO]  test: test info log: who=programmer\n", rest)
+
+	})
+
+	t.Run("Sends output to debug sink when logger is lower", func(t *testing.T) {
+		var logBuf bytes.Buffer
+		var sinkBuf bytes.Buffer
+
+		logger := NewMultiSink(&LoggerOptions{
+			Level:  Info,
+			Name:   "test",
+			Output: &logBuf,
+		})
+
+		sink := NewSink(&SinkOptions{
+			Level:  Debug,
+			Output: &sinkBuf,
+		})
+
+		logger.RegisterSink(sink)
+
+		logger.Debug("test debug")
+
+		str := sinkBuf.String()
+		dataIdx := strings.IndexByte(str, ' ')
+		rest := str[dataIdx+1:]
+
+		assert.Equal(t, "[DEBUG] test: test debug\n", rest)
+
+	})
+}
+
 type customErrJSON struct {
 	Message string
 }

--- a/logger_test.go
+++ b/logger_test.go
@@ -663,6 +663,34 @@ func TestMultiSinkLogger(t *testing.T) {
 		assert.Equal(t, "[DEBUG] test: test debug\n", rest)
 
 	})
+
+	t.Run("A new sublogger retains the parents sinks", func(t *testing.T) {
+		var logBuf bytes.Buffer
+		var sinkBuf bytes.Buffer
+
+		logger := NewMultiSink(&LoggerOptions{
+			Level:  Info,
+			Name:   "test",
+			Output: &logBuf,
+		})
+
+		sink := NewSink(&SinkOptions{
+			Level:  Debug,
+			Output: &sinkBuf,
+		})
+		logger.RegisterSink(sink)
+
+		sublogger := logger.Named("sublogger")
+
+		sublogger.Debug("test sublogger")
+
+		str := sinkBuf.String()
+		dataIdx := strings.IndexByte(str, ' ')
+		rest := str[dataIdx+1:]
+
+		assert.Equal(t, "[DEBUG] test.sublogger: test sublogger\n", rest)
+
+	})
 }
 
 type customErrJSON struct {

--- a/multisink_logger.go
+++ b/multisink_logger.go
@@ -1,0 +1,551 @@
+package hclog
+
+import (
+	"bytes"
+	"encoding"
+	"encoding/json"
+	"fmt"
+	"io"
+	"log"
+	"reflect"
+	"runtime"
+	"sort"
+	"strconv"
+	"strings"
+	"sync"
+	"sync/atomic"
+	"time"
+)
+
+// Make sure that sinkLogger is a Logger
+var _ Logger = &sinkLogger{}
+var _ MultiSinkLogger = &sinkLogger{}
+
+// sinkLogger is an internal logger implementation. Internal in that it is
+// defined entirely by this package.
+type sinkLogger struct {
+	json       bool
+	caller     bool
+	name       string
+	timeFormat string
+
+	// This is a pointer so that it's shared by any derived loggers, since
+	// those derived loggers share the bufio.Writer as well.
+	mutex       *sync.Mutex
+	writer      *writer
+	level       *int32
+	lowestLevel *int32
+
+	sinks map[*Sink]struct{}
+
+	implied []interface{}
+}
+
+// New returns a configured logger.
+func NewMultiSink(opts *LoggerOptions) MultiSinkLogger {
+	if opts == nil {
+		opts = &LoggerOptions{}
+	}
+
+	output := opts.Output
+	if output == nil {
+		output = DefaultOutput
+	}
+
+	level := opts.Level
+	if level == NoLevel {
+		level = DefaultLevel
+	}
+
+	mutex := opts.Mutex
+	if mutex == nil {
+		mutex = new(sync.Mutex)
+	}
+
+	l := &sinkLogger{
+		json:        opts.JSONFormat,
+		caller:      opts.IncludeLocation,
+		name:        opts.Name,
+		timeFormat:  TimeFormat,
+		mutex:       mutex,
+		writer:      newWriter(output),
+		level:       new(int32),
+		lowestLevel: new(int32),
+		sinks:       make(map[*Sink]struct{}),
+	}
+
+	if opts.TimeFormat != "" {
+		l.timeFormat = opts.TimeFormat
+	}
+
+	atomic.StoreInt32(l.lowestLevel, int32(level))
+	atomic.StoreInt32(l.level, int32(level))
+
+	return l
+}
+
+type Sink struct {
+	writer *writer
+	level  Level
+	json   bool
+}
+
+func NewSink(opts *SinkOptions) *Sink {
+	return &Sink{
+		level:  opts.Level,
+		json:   opts.JSONFormat,
+		writer: newWriter(opts.Output),
+	}
+}
+
+func (l *sinkLogger) RegisterSink(sink *Sink) {
+	l.mutex.Lock()
+	defer l.mutex.Unlock()
+
+	if sink.level < Level(atomic.LoadInt32(l.lowestLevel)) {
+		atomic.StoreInt32(l.lowestLevel, int32(sink.level))
+	}
+
+	if _, ok := l.sinks[sink]; ok {
+		return
+	}
+
+	l.sinks[sink] = struct{}{}
+}
+
+func (l *sinkLogger) DeregisterSink(sink *Sink) {
+	l.mutex.Lock()
+	defer l.mutex.Unlock()
+	delete(l.sinks, sink)
+}
+
+// Level returns the current level
+func (l *sinkLogger) Level() Level {
+	return Level(atomic.LoadInt32(l.level))
+}
+
+// Log a message and a set of key/value pairs if the given level is at
+// or more severe that the threshold configured in the Logger.
+func (l *sinkLogger) Log(level Level, msg string, args ...interface{}) {
+	if level < Level(atomic.LoadInt32(l.lowestLevel)) {
+		return
+	}
+
+	t := time.Now()
+
+	l.mutex.Lock()
+	defer l.mutex.Unlock()
+
+	for sink := range l.sinks {
+		if level < Level(sink.level) {
+			continue
+		}
+
+		lwriter := l.writer
+		l.writer = sink.writer
+
+		if sink.json {
+			l.logJSON(t, level, msg, args...)
+		} else {
+			l.log(t, level, msg, args...)
+		}
+		l.writer.Flush(level)
+
+		l.writer = lwriter
+
+	}
+
+	if level < Level(atomic.LoadInt32(l.level)) {
+		return
+	}
+
+	if l.json {
+		l.logJSON(t, level, msg, args...)
+	} else {
+		l.log(t, level, msg, args...)
+	}
+
+	l.writer.Flush(level)
+}
+
+// Non-JSON logging format function
+func (l *sinkLogger) log(t time.Time, level Level, msg string, args ...interface{}) {
+	l.writer.WriteString(t.Format(l.timeFormat))
+	l.writer.WriteByte(' ')
+
+	s, ok := _levelToBracket[level]
+	if ok {
+		l.writer.WriteString(s)
+	} else {
+		l.writer.WriteString("[?????]")
+	}
+
+	if l.caller {
+		if _, file, line, ok := runtime.Caller(3); ok {
+			l.writer.WriteByte(' ')
+			l.writer.WriteString(trimCallerPath(file))
+			l.writer.WriteByte(':')
+			l.writer.WriteString(strconv.Itoa(line))
+			l.writer.WriteByte(':')
+		}
+	}
+
+	l.writer.WriteByte(' ')
+
+	if l.name != "" {
+		l.writer.WriteString(l.name)
+		l.writer.WriteString(": ")
+	}
+
+	l.writer.WriteString(msg)
+
+	args = append(l.implied, args...)
+
+	var stacktrace CapturedStacktrace
+
+	if args != nil && len(args) > 0 {
+		if len(args)%2 != 0 {
+			cs, ok := args[len(args)-1].(CapturedStacktrace)
+			if ok {
+				args = args[:len(args)-1]
+				stacktrace = cs
+			} else {
+				args = append(args, "<unknown>")
+			}
+		}
+
+		l.writer.WriteByte(':')
+
+	FOR:
+		for i := 0; i < len(args); i = i + 2 {
+			var (
+				val string
+				raw bool
+			)
+
+			switch st := args[i+1].(type) {
+			case string:
+				val = st
+			case int:
+				val = strconv.FormatInt(int64(st), 10)
+			case int64:
+				val = strconv.FormatInt(int64(st), 10)
+			case int32:
+				val = strconv.FormatInt(int64(st), 10)
+			case int16:
+				val = strconv.FormatInt(int64(st), 10)
+			case int8:
+				val = strconv.FormatInt(int64(st), 10)
+			case uint:
+				val = strconv.FormatUint(uint64(st), 10)
+			case uint64:
+				val = strconv.FormatUint(uint64(st), 10)
+			case uint32:
+				val = strconv.FormatUint(uint64(st), 10)
+			case uint16:
+				val = strconv.FormatUint(uint64(st), 10)
+			case uint8:
+				val = strconv.FormatUint(uint64(st), 10)
+			case CapturedStacktrace:
+				stacktrace = st
+				continue FOR
+			case Format:
+				val = fmt.Sprintf(st[0].(string), st[1:]...)
+			default:
+				v := reflect.ValueOf(st)
+				if v.Kind() == reflect.Slice {
+					val = l.renderSlice(v)
+					raw = true
+				} else {
+					val = fmt.Sprintf("%v", st)
+				}
+			}
+
+			l.writer.WriteByte(' ')
+			l.writer.WriteString(args[i].(string))
+			l.writer.WriteByte('=')
+
+			if !raw && strings.ContainsAny(val, " \t\n\r") {
+				l.writer.WriteByte('"')
+				l.writer.WriteString(val)
+				l.writer.WriteByte('"')
+			} else {
+				l.writer.WriteString(val)
+			}
+		}
+	}
+
+	l.writer.WriteString("\n")
+
+	if stacktrace != "" {
+		l.writer.WriteString(string(stacktrace))
+	}
+}
+
+func (l *sinkLogger) renderSlice(v reflect.Value) string {
+	var buf bytes.Buffer
+
+	buf.WriteRune('[')
+
+	for i := 0; i < v.Len(); i++ {
+		if i > 0 {
+			buf.WriteString(", ")
+		}
+
+		sv := v.Index(i)
+
+		var val string
+
+		switch sv.Kind() {
+		case reflect.String:
+			val = sv.String()
+		case reflect.Int, reflect.Int16, reflect.Int32, reflect.Int64:
+			val = strconv.FormatInt(sv.Int(), 10)
+		case reflect.Uint, reflect.Uint16, reflect.Uint32, reflect.Uint64:
+			val = strconv.FormatUint(sv.Uint(), 10)
+		default:
+			val = fmt.Sprintf("%v", sv.Interface())
+		}
+
+		if strings.ContainsAny(val, " \t\n\r") {
+			buf.WriteByte('"')
+			buf.WriteString(val)
+			buf.WriteByte('"')
+		} else {
+			buf.WriteString(val)
+		}
+	}
+
+	buf.WriteRune(']')
+
+	return buf.String()
+}
+
+// JSON logging function
+func (l *sinkLogger) logJSON(t time.Time, level Level, msg string, args ...interface{}) {
+	vals := l.jsonMapEntry(t, level, msg)
+	args = append(l.implied, args...)
+
+	if args != nil && len(args) > 0 {
+		if len(args)%2 != 0 {
+			cs, ok := args[len(args)-1].(CapturedStacktrace)
+			if ok {
+				args = args[:len(args)-1]
+				vals["stacktrace"] = cs
+			} else {
+				args = append(args, "<unknown>")
+			}
+		}
+
+		for i := 0; i < len(args); i = i + 2 {
+			if _, ok := args[i].(string); !ok {
+				// As this is the logging function not much we can do here
+				// without injecting into logs...
+				continue
+			}
+			val := args[i+1]
+			switch sv := val.(type) {
+			case error:
+				// Check if val is of type error. If error type doesn't
+				// implement json.Marshaler or encoding.TextMarshaler
+				// then set val to err.Error() so that it gets marshaled
+				switch sv.(type) {
+				case json.Marshaler, encoding.TextMarshaler:
+				default:
+					val = sv.Error()
+				}
+			case Format:
+				val = fmt.Sprintf(sv[0].(string), sv[1:]...)
+			}
+
+			vals[args[i].(string)] = val
+		}
+	}
+
+	err := json.NewEncoder(l.writer).Encode(vals)
+	if err != nil {
+		if _, ok := err.(*json.UnsupportedTypeError); ok {
+			plainVal := l.jsonMapEntry(t, level, msg)
+			plainVal["@warn"] = errJsonUnsupportedTypeMsg
+
+			json.NewEncoder(l.writer).Encode(plainVal)
+		}
+	}
+}
+
+func (l sinkLogger) jsonMapEntry(t time.Time, level Level, msg string) map[string]interface{} {
+	vals := map[string]interface{}{
+		"@message":   msg,
+		"@timestamp": t.Format("2006-01-02T15:04:05.000000Z07:00"),
+	}
+
+	var levelStr string
+	switch level {
+	case Error:
+		levelStr = "error"
+	case Warn:
+		levelStr = "warn"
+	case Info:
+		levelStr = "info"
+	case Debug:
+		levelStr = "debug"
+	case Trace:
+		levelStr = "trace"
+	default:
+		levelStr = "all"
+	}
+
+	vals["@level"] = levelStr
+
+	if l.name != "" {
+		vals["@module"] = l.name
+	}
+
+	if l.caller {
+		if _, file, line, ok := runtime.Caller(4); ok {
+			vals["@caller"] = fmt.Sprintf("%s:%d", file, line)
+		}
+	}
+	return vals
+}
+
+// Emit the message and args at DEBUG level
+func (l *sinkLogger) Debug(msg string, args ...interface{}) {
+	l.Log(Debug, msg, args...)
+}
+
+// Emit the message and args at TRACE level
+func (l *sinkLogger) Trace(msg string, args ...interface{}) {
+	l.Log(Trace, msg, args...)
+}
+
+// Emit the message and args at INFO level
+func (l *sinkLogger) Info(msg string, args ...interface{}) {
+	l.Log(Info, msg, args...)
+}
+
+// Emit the message and args at WARN level
+func (l *sinkLogger) Warn(msg string, args ...interface{}) {
+	l.Log(Warn, msg, args...)
+}
+
+// Emit the message and args at ERROR level
+func (l *sinkLogger) Error(msg string, args ...interface{}) {
+	l.Log(Error, msg, args...)
+}
+
+// Indicate that the logger would emit TRACE level logs
+func (l *sinkLogger) IsTrace() bool {
+	return Level(atomic.LoadInt32(l.level)) == Trace
+}
+
+// Indicate that the logger would emit DEBUG level logs
+func (l *sinkLogger) IsDebug() bool {
+	return Level(atomic.LoadInt32(l.level)) <= Debug
+}
+
+// Indicate that the logger would emit INFO level logs
+func (l *sinkLogger) IsInfo() bool {
+	return Level(atomic.LoadInt32(l.level)) <= Info
+}
+
+// Indicate that the logger would emit WARN level logs
+func (l *sinkLogger) IsWarn() bool {
+	return Level(atomic.LoadInt32(l.level)) <= Warn
+}
+
+// Indicate that the logger would emit ERROR level logs
+func (l *sinkLogger) IsError() bool {
+	return Level(atomic.LoadInt32(l.level)) <= Error
+}
+
+// Return a sub-Logger for which every emitted log message will contain
+// the given key/value pairs. This is used to create a context specific
+// Logger.
+func (l *sinkLogger) With(args ...interface{}) Logger {
+	if len(args)%2 != 0 {
+		panic("With() call requires paired arguments")
+	}
+
+	sl := *l
+
+	result := make(map[string]interface{}, len(l.implied)+len(args))
+	keys := make([]string, 0, len(l.implied)+len(args))
+
+	// Read existing args, store map and key for consistent sorting
+	for i := 0; i < len(l.implied); i += 2 {
+		key := l.implied[i].(string)
+		keys = append(keys, key)
+		result[key] = l.implied[i+1]
+	}
+	// Read new args, store map and key for consistent sorting
+	for i := 0; i < len(args); i += 2 {
+		key := args[i].(string)
+		_, exists := result[key]
+		if !exists {
+			keys = append(keys, key)
+		}
+		result[key] = args[i+1]
+	}
+
+	// Sort keys to be consistent
+	sort.Strings(keys)
+
+	sl.implied = make([]interface{}, 0, len(l.implied)+len(args))
+	for _, k := range keys {
+		sl.implied = append(sl.implied, k)
+		sl.implied = append(sl.implied, result[k])
+	}
+
+	return &sl
+}
+
+// Create a new sub-Logger that a name decending from the current name.
+// This is used to create a subsystem specific Logger.
+func (l *sinkLogger) Named(name string) Logger {
+	sl := *l
+
+	if sl.name != "" {
+		sl.name = sl.name + "." + name
+	} else {
+		sl.name = name
+	}
+
+	return &sl
+}
+
+// Create a new sub-Logger with an explicit name. This ignores the current
+// name. This is used to create a standalone logger that doesn't fall
+// within the normal hierarchy.
+func (l *sinkLogger) ResetNamed(name string) Logger {
+	sl := *l
+
+	sl.name = name
+
+	return &sl
+}
+
+// Update the logging level on-the-fly. This will affect all subloggers as
+// well.
+func (l *sinkLogger) SetLevel(level Level) {
+	atomic.StoreInt32(l.level, int32(level))
+}
+
+// Create a *log.Logger that will send it's data through this Logger. This
+// allows packages that expect to be using the standard library log to actually
+// use this logger.
+func (l *sinkLogger) StandardLogger(opts *StandardLoggerOptions) *log.Logger {
+	if opts == nil {
+		opts = &StandardLoggerOptions{}
+	}
+
+	return log.New(l.StandardWriter(opts), "", 0)
+}
+
+func (l *sinkLogger) StandardWriter(opts *StandardLoggerOptions) io.Writer {
+	return &stdlogAdapter{
+		log:         l,
+		inferLevels: opts.InferLevels,
+		forceLevel:  opts.ForceLevel,
+	}
+}

--- a/multisink_logger.go
+++ b/multisink_logger.go
@@ -94,12 +94,12 @@ func (l *sinkLogger) RegisterSink(sink *Sink) {
 	l.mutex.Lock()
 	defer l.mutex.Unlock()
 
-	if sink.level < Level(atomic.LoadInt32(l.lowestLevel)) {
-		atomic.StoreInt32(l.lowestLevel, int32(sink.level))
-	}
-
 	if _, ok := l.sinks[sink]; ok {
 		return
+	}
+
+	if sink.level < Level(atomic.LoadInt32(l.lowestLevel)) {
+		atomic.StoreInt32(l.lowestLevel, int32(sink.level))
 	}
 
 	l.sinks[sink] = struct{}{}

--- a/multisink_logger.go
+++ b/multisink_logger.go
@@ -280,6 +280,31 @@ func (l *sinkLogger) With(args ...interface{}) Logger {
 
 // Create a new sub-Logger that a name decending from the current name.
 // This is used to create a subsystem specific Logger.
+func (l *sinkLogger) NamedMultiSink(name string) MultiSinkLogger {
+	sl := *l
+
+	if sl.name != "" {
+		sl.name = sl.name + "." + name
+	} else {
+		sl.name = name
+	}
+
+	return &sl
+}
+
+// Create a new sub-Logger with an explicit name. This ignores the current
+// name. This is used to create a standalone logger that doesn't fall
+// within the normal hierarchy.
+func (l *sinkLogger) ResetNamedMultiSink(name string) MultiSinkLogger {
+	sl := *l
+
+	sl.name = name
+
+	return &sl
+}
+
+// Create a new sub-Logger that a name decending from the current name.
+// This is used to create a subsystem specific Logger.
 func (l *sinkLogger) Named(name string) Logger {
 	sl := *l
 

--- a/multisink_logger.go
+++ b/multisink_logger.go
@@ -161,26 +161,27 @@ func (l *sinkLogger) Log(level Level, msg string, args ...interface{}) {
 
 // Non-JSON logging format function
 func (l *sinkLogger) log(t time.Time, level Level, msg string, args ...interface{}) bytes.Buffer {
-	return build(&logLine{
-		w:       l.writer,
+	ld := &lineDetails{
 		t:       t,
 		tfmt:    l.timeFormat,
 		name:    l.name,
 		caller:  l.caller,
 		implied: l.implied,
-	}, level, msg, args...)
+	}
+	return ld.build(level, msg, args...)
 }
 
 // JSON logging function
 func (l *sinkLogger) logJSON(t time.Time, level Level, msg string, args ...interface{}) bytes.Buffer {
-	return buildJSON(&logLine{
-		w:       l.writer,
+	ld := &lineDetails{
 		t:       t,
 		tfmt:    l.timeFormat,
 		name:    l.name,
 		caller:  l.caller,
 		implied: l.implied,
-	}, level, msg, args...)
+	}
+
+	return ld.buildJSON(level, msg, args...)
 }
 
 // Emit the message and args at DEBUG level


### PR DESCRIPTION
This PR aims to add support for a new logger which can register and deregister multiple sinks. The main intended use case provides the ability to listen to logs with a lower log level than that of the root logger, without writing to the root loggers writer.

Since the internals of building a log line for unstructured and json were identical between the two I've moved that logic into a shared `lineDetail.build / buildJSON` helper.

Happy to discuss alternatives, still need to add a few tests and update the readme if this is an acceptable approach.