### PR TITLE
Add interface to allow StandardLoggers to also log

### DIFF
--- a/interceptlogger_test.go
+++ b/interceptlogger_test.go
@@ -226,4 +226,36 @@ func TestInterceptLogger(t *testing.T) {
 		rest := output[dataIdx+1:]
 		assert.Equal(t, "[DEBUG] with_test.sub_logger.http: test1: parent=logger path=/some/test/path args=[test, test]\n", rest)
 	})
+
+	t.Run("derived standard loggers send output to sinks", func(t *testing.T) {
+		var buf bytes.Buffer
+		var sbuf bytes.Buffer
+
+		intercept := NewInterceptLogger(&LoggerOptions{
+			Name:   "with_name",
+			Level:  Debug,
+			Output: &buf,
+		})
+
+		standard := intercept.StandardLoggerIntercept(&StandardLoggerOptions{InferLevels: true})
+
+		sink := NewSinkAdapter(&LoggerOptions{
+			Level:  Debug,
+			Output: &sbuf,
+		})
+		intercept.RegisterSink(sink)
+		defer intercept.DeregisterSink(sink)
+
+		standard.Println("[DEBUG] test log")
+
+		output := buf.String()
+		dataIdx := strings.IndexByte(output, ' ')
+		rest := output[dataIdx+1:]
+		assert.Equal(t, "[DEBUG] with_name: test log\n", rest)
+
+		output = sbuf.String()
+		dataIdx = strings.IndexByte(output, ' ')
+		rest = output[dataIdx+1:]
+		assert.Equal(t, "[DEBUG] with_name: test log\n", rest)
+	})
 }

--- a/logger.go
+++ b/logger.go
@@ -225,6 +225,12 @@ type InterceptLogger interface {
 	// This sets the name of the logger to the value directly, unlike Named which honor
 	// the current name as well.
 	ResetNamedIntercept(name string) InterceptLogger
+
+	// Return a value that conforms to the stdlib log.Logger interface
+	StandardLoggerIntercept(opts *StandardLoggerOptions) *log.Logger
+
+	// Return a value that conforms to io.Writer, which can be passed into log.SetOutput()
+	StandardWriterIntercept(opts *StandardLoggerOptions) io.Writer
 }
 
 // SinkAdapter describes the interface that must be implemented


### PR DESCRIPTION
Creates StandardLoggerIntercept and StandardWriterIntercept so that
Intercepting loggers can create StandardLoggers and maintain the ability
to write to registered sinks