### PR TITLE
Add a Log function for logging at a given level

### DIFF
--- a/logger.go
+++ b/logger.go
@@ -95,6 +95,9 @@ type Logger interface {
 	// Args are alternating key, val pairs
 	// keys must be strings
 	// vals can be any type, but display is implementation specific
+	// Emit a message and key/value pairs at a provided log level
+	Log(level Level, msg string, args ...interface{})
+
 	// Emit a message and key/value pairs at the TRACE level
 	Trace(msg string, args ...interface{})
 

--- a/nulllogger.go
+++ b/nulllogger.go
@@ -15,6 +15,8 @@ func NewNullLogger() Logger {
 
 type nullLogger struct{}
 
+func (l *nullLogger) Log(level Level, msg string, args ...interface{}) {}
+
 func (l *nullLogger) Trace(msg string, args ...interface{}) {}
 
 func (l *nullLogger) Debug(msg string, args ...interface{}) {}


### PR DESCRIPTION
This PR is currently a proposal, and has not really undergone any
testing beyond "does it build" and "does go test pass".

### Background

While writing some middleware for logging gRPC requests in Nomad, I ran
into a situation where I want to log different response types at
different levels, and need to make those overridable by different
consumers in the middleware.

Ideally, this would be achieved with a lookup like so:

```go
func DefaultCodeToLevel(code codes.Code) logrus.Level {
	switch code {
	// Debug Logs
	case codes.OK:
		return hclog.Debug
	case codes.Canceled:
		return hclog.Debug
	case codes.InvalidArgument:
		return hclog.Debug
	case codes.ResourceExhausted:
		return hclog.Debug
	case codes.FailedPrecondition:
		return hclog.Debug
	case codes.Aborted:
		return hclog.Debug
	case codes.OutOfRange:
		return hclog.Debug
	case codes.NotFound:
		return hclog.Debug
	case codes.AlreadyExists:
		return hclog.Debug

	// Info Logs - More curious/interesting than debug, but not necessarily critical
	case codes.Unknown:
		return hclog.Info
	case codes.DeadlineExceeded:
		return hclog.Info
	case codes.PermissionDenied:
		return hclog.Info
...
```

This would then be used by the actual log emitter, to provide different
levels of log.

Currently, with hclog, this requires then doing another lookup in the
implementation to switch over all log types to then emit at the
desired level.

e.g

```go
switch CodeTolevel(code) {
        case hclog.Trace:
          logger.Trace(..., complex, arg, setup, here)
}
```

Which quickly reduces the clarity and readability of the logging code,
or involves having the CodeToLevel implementation return a higher level
function for providing the correct logging fn, which is also fairly
difficult for many developers to quickly understand.

This PR reduces that to the following, which maintains the intent and
clarity of the code, and allows multiple different loggers to be
targeted easily.

```go
level := o.codeToLevelFunc(resp.Code)
logger.Log(level, "msg", args, go, here, and, can, be, long)
```