### PR TITLE
Adds ResetOutput and ResetOutputWithFlush

### DIFF
--- a/intlogger.go
+++ b/intlogger.go
@@ -563,18 +563,27 @@ func (l *intLogger) ResetNamed(name string) Logger {
 }
 
 func (l *intLogger) ResetOutput(opts *LoggerOptions) error {
+	if opts.Output == nil {
+		return errors.New("given output is nil")
+	}
+
 	l.mutex.Lock()
 	defer l.mutex.Unlock()
+
 	return l.resetOutput(opts)
 }
 
 func (l *intLogger) ResetOutputWithFlush(opts *LoggerOptions, flushable Flushable) error {
-	l.mutex.Lock()
-	defer l.mutex.Unlock()
-
+	if opts.Output == nil {
+		return errors.New("given output is nil")
+	}
 	if flushable == nil {
 		return errors.New("flushable is nil")
 	}
+
+	l.mutex.Lock()
+	defer l.mutex.Unlock()
+
 	if err := flushable.Flush(); err != nil {
 		return err
 	}
@@ -583,10 +592,6 @@ func (l *intLogger) ResetOutputWithFlush(opts *LoggerOptions, flushable Flushabl
 }
 
 func (l *intLogger) resetOutput(opts *LoggerOptions) error {
-	if opts.Output == nil {
-		return errors.New("given output is nil")
-	}
-
 	l.writer = newWriter(opts.Output, opts.Color)
 	l.setColorization(opts)
 	return nil

--- a/intlogger.go
+++ b/intlogger.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"encoding"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"log"
@@ -559,6 +560,36 @@ func (l *intLogger) ResetNamed(name string) Logger {
 	sl.name = name
 
 	return &sl
+}
+
+func (l *intLogger) ResetOutput(opts *LoggerOptions) error {
+	l.mutex.Lock()
+	defer l.mutex.Unlock()
+	return l.resetOutput(opts)
+}
+
+func (l *intLogger) ResetOutputWithFlush(opts *LoggerOptions, flushable Flushable) error {
+	l.mutex.Lock()
+	defer l.mutex.Unlock()
+
+	if flushable == nil {
+		return errors.New("flushable is nil")
+	}
+	if err := flushable.Flush(); err != nil {
+		return err
+	}
+
+	return l.resetOutput(opts)
+}
+
+func (l *intLogger) resetOutput(opts *LoggerOptions) error {
+	if opts.Output == nil {
+		return errors.New("given output is nil")
+	}
+
+	l.writer = newWriter(opts.Output, opts.Color)
+	l.setColorization(opts)
+	return nil
 }
 
 // Update the logging level on-the-fly. This will affect all subloggers as

--- a/logger.go
+++ b/logger.go
@@ -149,15 +149,6 @@ type Logger interface {
 	// the current name as well.
 	ResetNamed(name string) Logger
 
-	// ResetOutput swaps the current output writer with the one given in the
-	// opts. Color options given in opts will be used for the new output.
-	ResetOutput(opts *LoggerOptions) error
-
-	// ResetOutputWithFlush swaps the current output writer with the one given
-	// in the opts, first calling Flush on the given Flushable. Color options
-	// given in opts will be used for the new output.
-	ResetOutputWithFlush(opts *LoggerOptions, flushable Flushable) error
-
 	// Updates the level. This should affect all sub-loggers as well. If an
 	// implementation cannot update the level on the fly, it should no-op.
 	SetLevel(level Level)
@@ -256,4 +247,16 @@ type SinkAdapter interface {
 // the existing output beforehand.
 type Flushable interface {
 	Flush() error
+}
+
+// OutputResettable provides ways to swap the output in use at runtime
+type OutputResettable interface {
+	// ResetOutput swaps the current output writer with the one given in the
+	// opts. Color options given in opts will be used for the new output.
+	ResetOutput(opts *LoggerOptions) error
+
+	// ResetOutputWithFlush swaps the current output writer with the one given
+	// in the opts, first calling Flush on the given Flushable. Color options
+	// given in opts will be used for the new output.
+	ResetOutputWithFlush(opts *LoggerOptions, flushable Flushable) error
 }

--- a/logger.go
+++ b/logger.go
@@ -149,6 +149,15 @@ type Logger interface {
 	// the current name as well.
 	ResetNamed(name string) Logger
 
+	// ResetOutput swaps the current output writer with the one given in the
+	// opts. Color options given in opts will be used for the new output.
+	ResetOutput(opts *LoggerOptions) error
+
+	// ResetOutputWithFlush swaps the current output writer with the one given
+	// in the opts, first calling Flush on the given Flushable. Color options
+	// given in opts will be used for the new output.
+	ResetOutputWithFlush(opts *LoggerOptions, flushable Flushable) error
+
 	// Updates the level. This should affect all sub-loggers as well. If an
 	// implementation cannot update the level on the fly, it should no-op.
 	SetLevel(level Level)
@@ -240,4 +249,11 @@ type InterceptLogger interface {
 // in order to Register a new sink to an InterceptLogger
 type SinkAdapter interface {
 	Accept(name string, level Level, msg string, args ...interface{})
+}
+
+// Flushable represents a method for flushing an output buffer. It can be used
+// if Resetting the log to use a new output, in order to flush the writes to
+// the existing output beforehand.
+type Flushable interface {
+	Flush() error
 }

--- a/logger_test.go
+++ b/logger_test.go
@@ -350,7 +350,7 @@ func TestLogger(t *testing.T) {
 
 		assert.Equal(t, "[INFO]  this is test: production=\"12 beans/day\"\n", rest)
 
-		logger.ResetOutput(&LoggerOptions{
+		logger.(OutputResettable).ResetOutput(&LoggerOptions{
 			Output: &second,
 		})
 
@@ -380,7 +380,7 @@ func TestLogger(t *testing.T) {
 		str := first.String()
 		assert.Empty(t, str)
 
-		logger.ResetOutputWithFlush(&LoggerOptions{
+		logger.(OutputResettable).ResetOutputWithFlush(&LoggerOptions{
 			Output: &second,
 		}, &first)
 

--- a/nulllogger.go
+++ b/nulllogger.go
@@ -47,10 +47,6 @@ func (l *nullLogger) Named(name string) Logger { return l }
 
 func (l *nullLogger) ResetNamed(name string) Logger { return l }
 
-func (l *nullLogger) ResetOutput(opts *LoggerOptions) error { return nil }
-
-func (l *nullLogger) ResetOutputWithFlush(opts *LoggerOptions, flushable Flushable) error { return nil }
-
 func (l *nullLogger) SetLevel(level Level) {}
 
 func (l *nullLogger) StandardLogger(opts *StandardLoggerOptions) *log.Logger {

--- a/nulllogger.go
+++ b/nulllogger.go
@@ -47,6 +47,10 @@ func (l *nullLogger) Named(name string) Logger { return l }
 
 func (l *nullLogger) ResetNamed(name string) Logger { return l }
 
+func (l *nullLogger) ResetOutput(opts *LoggerOptions) error { return nil }
+
+func (l *nullLogger) ResetOutputWithFlush(opts *LoggerOptions, flushable Flushable) error { return nil }
+
 func (l *nullLogger) SetLevel(level Level) {}
 
 func (l *nullLogger) StandardLogger(opts *StandardLoggerOptions) *log.Logger {


### PR DESCRIPTION
This can be used if you want to change the destination of your output
without application logic having to implement a second mutex to do so.