### PR TITLE
Add OutputResettable conformance to InterceptLogger

### DIFF
--- a/interceptlogger.go
+++ b/interceptlogger.go
@@ -213,18 +213,34 @@ func (i *interceptLogger) DeregisterSink(sink SinkAdapter) {
 // Create a *log.Logger that will send it's data through this Logger. This
 // allows packages that expect to be using the standard library to log to
 // actually use this logger, which will also send to any registered sinks.
-func (l *interceptLogger) StandardLoggerIntercept(opts *StandardLoggerOptions) *log.Logger {
+func (i *interceptLogger) StandardLoggerIntercept(opts *StandardLoggerOptions) *log.Logger {
 	if opts == nil {
 		opts = &StandardLoggerOptions{}
 	}
 
-	return log.New(l.StandardWriterIntercept(opts), "", 0)
+	return log.New(i.StandardWriterIntercept(opts), "", 0)
 }
 
-func (l *interceptLogger) StandardWriterIntercept(opts *StandardLoggerOptions) io.Writer {
+func (i *interceptLogger) StandardWriterIntercept(opts *StandardLoggerOptions) io.Writer {
 	return &stdlogAdapter{
-		log:         l,
+		log:         i,
 		inferLevels: opts.InferLevels,
 		forceLevel:  opts.ForceLevel,
+	}
+}
+
+func (i *interceptLogger) ResetOutput(opts *LoggerOptions) error {
+	if or, ok := i.Logger.(OutputResettable); ok {
+		return or.ResetOutput(opts)
+	} else {
+		return nil
+	}
+}
+
+func (i *interceptLogger) ResetOutputWithFlush(opts *LoggerOptions, flushable Flushable) error {
+	if or, ok := i.Logger.(OutputResettable); ok {
+		return or.ResetOutputWithFlush(opts, flushable)
+	} else {
+		return nil
 	}
 }

--- a/logger_test.go
+++ b/logger_test.go
@@ -151,7 +151,7 @@ func TestLogger(t *testing.T) {
 		rest := str[dataIdx+1:]
 
 		// This test will break if you move this around, it's line dependent, just fyi
-		assert.Equal(t, "[INFO]  go-hclog/logger_test.go:129: test: this is test: who=programmer why=\"testing is fun\"\n", rest)
+		assert.Equal(t, "[INFO]  go-hclog/logger_test.go:147: test: this is test: who=programmer why=\"testing is fun\"\n", rest)
 	})
 
 	t.Run("prefixes the name", func(t *testing.T) {
@@ -396,7 +396,6 @@ func TestLogger(t *testing.T) {
 		rest = str[dataIdx+1:]
 		assert.Equal(t, "[INFO]  this is another test: production=\"13 beans/day\"\n", rest)
 	})
-
 }
 
 func TestLogger_leveledWriter(t *testing.T) {


### PR DESCRIPTION
Full disclosure: I'm pretty new to Go so it's possible this isn't the best solution.

Closes https://github.com/hashicorp/go-hclog/issues/61