### PR TITLE
This adds the ability for the caller to be responsible for locking

### DIFF
--- a/intlogger.go
+++ b/intlogger.go
@@ -53,11 +53,10 @@ var _ Logger = &intLogger{}
 // intLogger is an internal logger implementation. Internal in that it is
 // defined entirely by this package.
 type intLogger struct {
-	json                        bool
-	caller                      bool
-	name                        string
-	timeFormat                  string
-	callerResponsibleForLocking bool
+	json       bool
+	caller     bool
+	name       string
+	timeFormat string
 
 	// This is a pointer so that it's shared by any derived loggers, since
 	// those derived loggers share the bufio.Writer as well.

--- a/intlogger.go
+++ b/intlogger.go
@@ -93,13 +93,9 @@ func newLogger(opts *LoggerOptions) *intLogger {
 		level = DefaultLevel
 	}
 
-	locker := opts.Locker
+	locker := opts.Mutex
 	if locker == nil {
-		mutex := opts.Mutex
-		if mutex == nil {
-			mutex = new(sync.Mutex)
-		}
-		locker = DefaultLocker{Mutex: mutex}
+		locker = new(sync.Mutex)
 	}
 
 	l := &intLogger{

--- a/logger.go
+++ b/logger.go
@@ -5,7 +5,6 @@ import (
 	"log"
 	"os"
 	"strings"
-	"sync"
 )
 
 var (
@@ -205,14 +204,10 @@ type LoggerOptions struct {
 	// Where to write the logs to. Defaults to os.Stderr if nil
 	Output io.Writer
 
-	// An optional mutex pointer in case Output is shared. Deprecated; use
-	// Locker with a DefaultLocker and set your preferred mutex there. If both
-	// this and Locker are set, Locker will be preferred.
-	Mutex *sync.Mutex
-
-	// If set uses the given Locker; otherwise a DefaultLocker will be
-	// instantiated and used internally.
-	Locker Locker
+	// An optional Locker in case Output is shared. This can be a sync.Mutex or
+	// a NoopLocker if the caller wants control over output, e.g. for batching
+	// log lines.
+	Mutex Locker
 
 	// Control if the output should be in JSON.
 	JSONFormat bool
@@ -296,11 +291,6 @@ type Locker interface {
 	Unlock()
 }
 
-// DefaultLocker implements Locker using a standard sync.Mutex
-type DefaultLocker struct {
-	*sync.Mutex
-}
-
 // NoopLocker implements locker but does nothing. This is useful if the client
 // wants tight control over locking, in order to provide grouping of log
 // entries or other functionality.
@@ -312,5 +302,4 @@ func (n NoopLocker) Lock() {}
 // Unlock does nothing
 func (n NoopLocker) Unlock() {}
 
-var _ Locker = (*DefaultLocker)(nil)
 var _ Locker = (*NoopLocker)(nil)

--- a/logger.go
+++ b/logger.go
@@ -282,7 +282,7 @@ type OutputResettable interface {
 }
 
 // Locker is used for locking output. If not set when creating a logger, a
-// DefaultLocker will be used which uses a sync.Mutex internally.
+// sync.Mutex will be used internally.
 type Locker interface {
 	// Lock is called when the output is going to be changed or written to
 	Lock()

--- a/logger.go
+++ b/logger.go
@@ -206,8 +206,8 @@ type LoggerOptions struct {
 	Output io.Writer
 
 	// An optional mutex pointer in case Output is shared. Deprecated; use
-	// Locker with a DefaultLocker and set this as the mutex. If both are set
-	// the Locker will be preferred.
+	// Locker with a DefaultLocker and set your preferred mutex there. If both
+	// this and Locker are set, Locker will be preferred.
 	Mutex *sync.Mutex
 
 	// If set uses the given Locker; otherwise a DefaultLocker will be

--- a/logger.go
+++ b/logger.go
@@ -208,6 +208,12 @@ type LoggerOptions struct {
 	// An optional mutex pointer in case Output is shared
 	Mutex *sync.Mutex
 
+	// If true, the caller will be responsible for locking and unlocking the
+	// mutex. This can be used in situations where a caller wants to write
+	// multiple related log entries, guaranteeing that they are grouped
+	// together.
+	CallerResponsibleForLocking bool
+
 	// Control if the output should be in JSON.
 	JSONFormat bool
 

--- a/logger_test.go
+++ b/logger_test.go
@@ -9,6 +9,7 @@ import (
 	"runtime"
 	"strconv"
 	"strings"
+	"sync"
 	"testing"
 	"time"
 
@@ -395,6 +396,18 @@ func TestLogger(t *testing.T) {
 		dataIdx = strings.IndexByte(str, ' ')
 		rest = str[dataIdx+1:]
 		assert.Equal(t, "[INFO]  this is another test: production=\"13 beans/day\"\n", rest)
+	})
+
+	t.Run("does not deadlock if caller responsible for locking", func(t *testing.T) {
+		mutex := new(sync.Mutex)
+		logger := New(&LoggerOptions{
+			Mutex:                       mutex,
+			CallerResponsibleForLocking: true,
+		})
+
+		mutex.Lock()
+		logger.Info("this is a test")
+		mutex.Unlock()
 	})
 }
 

--- a/logger_test.go
+++ b/logger_test.go
@@ -9,7 +9,6 @@ import (
 	"runtime"
 	"strconv"
 	"strings"
-	"sync"
 	"testing"
 	"time"
 
@@ -396,18 +395,6 @@ func TestLogger(t *testing.T) {
 		dataIdx = strings.IndexByte(str, ' ')
 		rest = str[dataIdx+1:]
 		assert.Equal(t, "[INFO]  this is another test: production=\"13 beans/day\"\n", rest)
-	})
-
-	t.Run("does not deadlock if caller responsible for locking", func(t *testing.T) {
-		mutex := new(sync.Mutex)
-		logger := New(&LoggerOptions{
-			Mutex:                       mutex,
-			CallerResponsibleForLocking: true,
-		})
-
-		mutex.Lock()
-		logger.Info("this is a test")
-		mutex.Unlock()
 	})
 }
 


### PR DESCRIPTION
This has a number of use cases, chiefly allowing multiple related log
lines to be grouped together. It also reduces mutex contention in this
case.