### PR TITLE
Provide a way to filter out log messages easily

### DIFF
--- a/exclude.go
+++ b/exclude.go
@@ -9,17 +9,17 @@ import (
 // can be queried and matched. This is meant to be used with the Exclude
 // option on Options to suppress log messages. This does not hold any mutexs
 // within itself, so normal usage would be to Add entries at setup and none after
-// Filter is going to be called. Filter is called with a mutex held within
+// Exclude is going to be called. Exclude is called with a mutex held within
 // the Logger, so that doesn't need to use a mutex. Example usage:
 //
 //	f := new(ExcludeByMessage)
 //	f.Add("Noisy log message text")
-//	appLogger.Filter = f.Filter
+//	appLogger.Exclude = f.Exclude
 type ExcludeByMessage struct {
 	messages map[string]struct{}
 }
 
-// Add a message to be filtered. Do not call this after Filter is to be called
+// Add a message to be filtered. Do not call this after Exclude is to be called
 // due to concurrency issues.
 func (f *ExcludeByMessage) Add(msg string) {
 	if f.messages == nil {

--- a/exclude_test.go
+++ b/exclude_test.go
@@ -1,0 +1,55 @@
+package hclog
+
+import (
+	"regexp"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestExclude(t *testing.T) {
+	t.Run("excludes by message", func(t *testing.T) {
+		var em ExcludeByMessage
+		em.Add("foo")
+		em.Add("bar")
+
+		assert.True(t, em.Exclude(Info, "foo"))
+		assert.True(t, em.Exclude(Info, "bar"))
+		assert.False(t, em.Exclude(Info, "qux"))
+		assert.False(t, em.Exclude(Info, "foo qux"))
+		assert.False(t, em.Exclude(Info, "qux bar"))
+	})
+
+	t.Run("excludes by prefix", func(t *testing.T) {
+		ebp := ExcludeByPrefix("foo: ")
+
+		assert.True(t, ebp.Exclude(Info, "foo: rocks"))
+		assert.False(t, ebp.Exclude(Info, "foo"))
+		assert.False(t, ebp.Exclude(Info, "qux foo: bar"))
+	})
+
+	t.Run("exclude by regexp", func(t *testing.T) {
+		ebr := &ExcludeByRegexp{
+			Regexp: regexp.MustCompile("(foo|bar)"),
+		}
+
+		assert.True(t, ebr.Exclude(Info, "foo"))
+		assert.True(t, ebr.Exclude(Info, "bar"))
+		assert.True(t, ebr.Exclude(Info, "foo qux"))
+		assert.True(t, ebr.Exclude(Info, "qux bar"))
+		assert.False(t, ebr.Exclude(Info, "qux"))
+	})
+
+	t.Run("excludes many funcs", func(t *testing.T) {
+		ef := ExcludeFuncs{
+			ExcludeByPrefix("foo: ").Exclude,
+			ExcludeByPrefix("bar: ").Exclude,
+		}
+
+		assert.True(t, ef.Exclude(Info, "foo: rocks"))
+		assert.True(t, ef.Exclude(Info, "bar: rocks"))
+		assert.False(t, ef.Exclude(Info, "foo"))
+		assert.False(t, ef.Exclude(Info, "qux foo: bar"))
+
+	})
+}

--- a/filter.go
+++ b/filter.go
@@ -1,13 +1,13 @@
 package hclog
 
-// FilterOut provides a simple way to build a list of log messages that
-// can be queried and matched. This is meant to be used with the FilterOut
+// MessageFilter provides a simple way to build a list of log messages that
+// can be queried and matched. This is meant to be used with the MessageFilter
 // option on Options to suppress log messages.
-type FilterOut struct {
+type MessageFilter struct {
 	messages map[string]struct{}
 }
 
-func (f *FilterOut) Add(msg string) {
+func (f *MessageFilter) Add(msg string) {
 	if f.messages == nil {
 		f.messages = make(map[string]struct{})
 	}
@@ -15,7 +15,7 @@ func (f *FilterOut) Add(msg string) {
 	f.messages[msg] = struct{}{}
 }
 
-func (f *FilterOut) FilterOut(level Level, msg string, args ...interface{}) bool {
+func (f *MessageFilter) FilterOut(level Level, msg string, args ...interface{}) bool {
 	_, ok := f.messages[msg]
 	return ok
 }

--- a/filter.go
+++ b/filter.go
@@ -1,0 +1,21 @@
+package hclog
+
+// FilterOut provides a simple way to build a list of log messages that
+// can be queried and matched. This is meant to be used with the FilterOut
+// option on Options to suppress log messages.
+type FilterOut struct {
+	messages map[string]struct{}
+}
+
+func (f *FilterOut) Add(msg string) {
+	if f.messages == nil {
+		f.messages = make(map[string]struct{})
+	}
+
+	f.messages[msg] = struct{}{}
+}
+
+func (f *FilterOut) FilterOut(level Level, msg string, args ...interface{}) bool {
+	_, ok := f.messages[msg]
+	return ok
+}

--- a/filter.go
+++ b/filter.go
@@ -35,7 +35,7 @@ func (f *MessageFilter) FilterOut(level Level, msg string, args ...interface{}) 
 // PrefixFilter is a simple type to match a message string that has a common prefix.
 type PrefixFilter string
 
-// Matches an message that starts with the prefix.
+// Matches a message that starts with the prefix.
 func (p PrefixFilter) FilterOut(level Level, msg string, args ...interface{}) bool {
 	return strings.HasPrefix(msg, string(p))
 }

--- a/filter.go
+++ b/filter.go
@@ -2,7 +2,11 @@ package hclog
 
 // MessageFilter provides a simple way to build a list of log messages that
 // can be queried and matched. This is meant to be used with the Filter
-// option on Options to suppress log messages.
+// option on Options to suppress log messages. Example usage:
+//
+//	f := new(MessageFilter)
+//	f.Add("Noisy log message text")
+//	appLogger.Filter = f.FilterOut
 type MessageFilter struct {
 	messages map[string]struct{}
 }

--- a/filter.go
+++ b/filter.go
@@ -1,8 +1,13 @@
 package hclog
 
+import "strings"
+
 // MessageFilter provides a simple way to build a list of log messages that
 // can be queried and matched. This is meant to be used with the Filter
-// option on Options to suppress log messages. Example usage:
+// option on Options to suppress log messages. This does not hold any mutexs
+// within itself, so normal usage would be to Add entries at setup and none after
+// FilterOut is going to be called. FilterOut is called with a mutex held within
+// the Logger, so that doesn't need to use a mutex. Example usage:
 //
 //	f := new(MessageFilter)
 //	f.Add("Noisy log message text")
@@ -11,6 +16,8 @@ type MessageFilter struct {
 	messages map[string]struct{}
 }
 
+// Add a message to be filtered. Do not call this after FilterOut is to be called
+// due to concurrency issues.
 func (f *MessageFilter) Add(msg string) {
 	if f.messages == nil {
 		f.messages = make(map[string]struct{})
@@ -19,7 +26,32 @@ func (f *MessageFilter) Add(msg string) {
 	f.messages[msg] = struct{}{}
 }
 
+// Return true if the given message is known.
 func (f *MessageFilter) FilterOut(level Level, msg string, args ...interface{}) bool {
 	_, ok := f.messages[msg]
 	return ok
+}
+
+// PrefixFilter is a simple type to match a message string that has a common prefix.
+type PrefixFilter string
+
+// Matches an message that starts with the prefix.
+func (p PrefixFilter) FilterOut(level Level, msg string, args ...interface{}) bool {
+	return strings.HasPrefix(msg, string(p))
+}
+
+// FilterFuncs is a slice of functions that will called to see if a log entry
+// should be filtered or not. It stops calling functions once at least one returns
+// true.
+type FilterFuncs []func(level Level, msg string, args ...interface{}) bool
+
+// Calls each function until one of them returns true
+func (ff FilterFuncs) FilterOut(level Level, msg string, args ...interface{}) bool {
+	for _, f := range ff {
+		if f(level, msg, args...) {
+			return true
+		}
+	}
+
+	return false
 }

--- a/filter.go
+++ b/filter.go
@@ -40,7 +40,7 @@ func (p PrefixFilter) FilterOut(level Level, msg string, args ...interface{}) bo
 	return strings.HasPrefix(msg, string(p))
 }
 
-// FilterFuncs is a slice of functions that will called to see if a log entry
+// FilterFuncs is a slice of functions that will be called to see if a log entry
 // should be filtered or not. It stops calling functions once at least one returns
 // true.
 type FilterFuncs []func(level Level, msg string, args ...interface{}) bool

--- a/filter.go
+++ b/filter.go
@@ -1,7 +1,7 @@
 package hclog
 
 // MessageFilter provides a simple way to build a list of log messages that
-// can be queried and matched. This is meant to be used with the MessageFilter
+// can be queried and matched. This is meant to be used with the Filter
 // option on Options to suppress log messages.
 type MessageFilter struct {
 	messages map[string]struct{}

--- a/intlogger.go
+++ b/intlogger.go
@@ -66,7 +66,7 @@ type intLogger struct {
 
 	implied []interface{}
 
-	filter func(level Level, msg string, args ...interface{}) bool
+	exclude func(level Level, msg string, args ...interface{}) bool
 }
 
 // New returns a configured logger.
@@ -108,7 +108,7 @@ func newLogger(opts *LoggerOptions) *intLogger {
 		mutex:      mutex,
 		writer:     newWriter(output, opts.Color),
 		level:      new(int32),
-		filter:     opts.Filter,
+		exclude:    opts.Exclude,
 	}
 
 	l.setColorization(opts)
@@ -134,7 +134,7 @@ func (l *intLogger) log(name string, level Level, msg string, args ...interface{
 	l.mutex.Lock()
 	defer l.mutex.Unlock()
 
-	if l.filter != nil && l.filter(level, msg, args...) {
+	if l.exclude != nil && l.exclude(level, msg, args...) {
 		return
 	}
 

--- a/intlogger.go
+++ b/intlogger.go
@@ -65,6 +65,8 @@ type intLogger struct {
 	level  *int32
 
 	implied []interface{}
+
+	filterOut func(level Level, msg string, args ...interface{}) bool
 }
 
 // New returns a configured logger.
@@ -106,6 +108,7 @@ func newLogger(opts *LoggerOptions) *intLogger {
 		mutex:      mutex,
 		writer:     newWriter(output, opts.Color),
 		level:      new(int32),
+		filterOut:  opts.FilterOut,
 	}
 
 	l.setColorization(opts)
@@ -130,6 +133,10 @@ func (l *intLogger) log(name string, level Level, msg string, args ...interface{
 
 	l.mutex.Lock()
 	defer l.mutex.Unlock()
+
+	if l.filterOut != nil && l.filterOut(level, msg, args...) {
+		return
+	}
 
 	if l.json {
 		l.logJSON(t, name, level, msg, args...)

--- a/intlogger.go
+++ b/intlogger.go
@@ -66,7 +66,7 @@ type intLogger struct {
 
 	implied []interface{}
 
-	filterOut func(level Level, msg string, args ...interface{}) bool
+	filter func(level Level, msg string, args ...interface{}) bool
 }
 
 // New returns a configured logger.
@@ -108,7 +108,7 @@ func newLogger(opts *LoggerOptions) *intLogger {
 		mutex:      mutex,
 		writer:     newWriter(output, opts.Color),
 		level:      new(int32),
-		filterOut:  opts.FilterOut,
+		filter:     opts.Filter,
 	}
 
 	l.setColorization(opts)
@@ -134,7 +134,7 @@ func (l *intLogger) log(name string, level Level, msg string, args ...interface{
 	l.mutex.Lock()
 	defer l.mutex.Unlock()
 
-	if l.filterOut != nil && l.filterOut(level, msg, args...) {
+	if l.filter != nil && l.filter(level, msg, args...) {
 		return
 	}
 

--- a/logger.go
+++ b/logger.go
@@ -223,9 +223,10 @@ type LoggerOptions struct {
 	Color ColorOption
 
 	// A filter which is called with the log information and returns true if the value
-	// should actually be logged. This is useful when interacting with a system that
-	// you wish to suppress the log message for (because it's too noisy, etc)
-	FilterOut func(level Level, msg string, args ...interface{}) bool
+	// should not be logged (meaning return true it ignore the log entry).
+	// This is useful when interacting with a system that you wish to suppress the log
+	// message for (because it's too noisy, etc)
+	Filter func(level Level, msg string, args ...interface{}) bool
 }
 
 // InterceptLogger describes the interface for using a logger

--- a/logger.go
+++ b/logger.go
@@ -222,7 +222,7 @@ type LoggerOptions struct {
 	// are concretely instances of *os.File.
 	Color ColorOption
 
-	// A filter which is called with the log information and if it returns true the value
+	// A filter is a function which is called with the log information. If it returns true the value
 	// should not be logged.
 	// This is useful when interacting with a system that you wish to suppress the log
 	// message for (because it's too noisy, etc)

--- a/logger.go
+++ b/logger.go
@@ -222,11 +222,11 @@ type LoggerOptions struct {
 	// are concretely instances of *os.File.
 	Color ColorOption
 
-	// A filter is a function which is called with the log information. If it returns true the value
+	// A function which is called with the log information and if it returns true the value
 	// should not be logged.
 	// This is useful when interacting with a system that you wish to suppress the log
 	// message for (because it's too noisy, etc)
-	Filter func(level Level, msg string, args ...interface{}) bool
+	Exclude func(level Level, msg string, args ...interface{}) bool
 }
 
 // InterceptLogger describes the interface for using a logger

--- a/logger.go
+++ b/logger.go
@@ -221,6 +221,11 @@ type LoggerOptions struct {
 	// Color the output. On Windows, colored logs are only avaiable for io.Writers that
 	// are concretely instances of *os.File.
 	Color ColorOption
+
+	// A filter which is called with the log information and returns true if the value
+	// should actually be logged. This is useful when interacting with a system that
+	// you wish to suppress the log message for (because it's too noisy, etc)
+	FilterOut func(level Level, msg string, args ...interface{}) bool
 }
 
 // InterceptLogger describes the interface for using a logger

--- a/logger.go
+++ b/logger.go
@@ -222,8 +222,8 @@ type LoggerOptions struct {
 	// are concretely instances of *os.File.
 	Color ColorOption
 
-	// A filter which is called with the log information and returns true if the value
-	// should not be logged (meaning return true it ignore the log entry).
+	// A filter which is called with the log information and if it returns true the value
+	// should not be logged.
 	// This is useful when interacting with a system that you wish to suppress the log
 	// message for (because it's too noisy, etc)
 	Filter func(level Level, msg string, args ...interface{}) bool


### PR DESCRIPTION
When dealing with a package that logs too much, it can be desired to filter those log messages out. The only way to do that today is to implement a whole logger interface to hook into the proper point to filter them.

This instead adds a simple mechanism in intlogger to give the go/no-go on each log message before it's logged.