### PR TITLE
gomod caller does not match regex

### DIFF
--- a/intlogger.go
+++ b/intlogger.go
@@ -178,7 +178,7 @@ func trimCallerPath(path string) string {
 	return path[idx+1:]
 }
 
-var logImplFile = regexp.MustCompile(`github.com/hashicorp/go-hclog/.+logger.go$`)
+var logImplFile = regexp.MustCompile(`.+intlogger.go|.+interceptlogger.go$`)
 
 // Non-JSON logging format function
 func (l *intLogger) logPlain(t time.Time, name string, level Level, msg string, args ...interface{}) {


### PR DESCRIPTION
current regex is not compatible with go modules

```
    testlog.go:34: 2020-06-01T12:02:21.198-0400 [DEBUG] go-hclog@v0.14.1-0.20200601160029-72283a822461/interceptlogger.go:62: podman.podmanHandle: Stopping exitWatcher: container=8e0151443072a743d06f6d059413410a0889cc850658b9414ad15d67e99784c0
    testlog.go:34: 2020-06-01T12:02:21.198-0400 [DEBUG] go-hclog@v0.14.1-0.20200601160029-72283a822461/interceptlogger.go:62: podmanClient: Removing container: container=8e0151443072a743d06f6d059413410a0889cc850658b9414ad15d67e99784c0
    testlog.go:34: 2020-06-01T12:02:25.325-0400 [WARN]  go-hclog@v0.14.1-0.20200601160029-72283a822461/interceptlogger.go:90: driver_harness.logmon: timed out waiting for read-side of process output pipe to close
```
Open to not using a regex as well :thinking: 