### PR TITLE
Make sure that we include a newline when writing stack traces

### DIFF
--- a/intlogger.go
+++ b/intlogger.go
@@ -311,6 +311,7 @@ func (l *intLogger) logPlain(t time.Time, name string, level Level, msg string, 
 
 	if stacktrace != "" {
 		l.writer.WriteString(string(stacktrace))
+		l.writer.WriteString("\n")
 	}
 }
 


### PR DESCRIPTION
...so that the next log entry occurs on its own line.