### PR TITLE
Remove extra intercept methods

### DIFF
--- a/interceptlogger.go
+++ b/interceptlogger.go
@@ -210,18 +210,23 @@ func (i *interceptLogger) DeregisterSink(sink SinkAdapter) {
 	atomic.AddInt32(i.sinkCount, -1)
 }
 
-// Create a *log.Logger that will send it's data through this Logger. This
-// allows packages that expect to be using the standard library to log to
-// actually use this logger, which will also send to any registered sinks.
 func (i *interceptLogger) StandardLoggerIntercept(opts *StandardLoggerOptions) *log.Logger {
+	return i.StandardLogger(opts)
+}
+
+func (i *interceptLogger) StandardLogger(opts *StandardLoggerOptions) *log.Logger {
 	if opts == nil {
 		opts = &StandardLoggerOptions{}
 	}
 
-	return log.New(i.StandardWriterIntercept(opts), "", 0)
+	return log.New(i.StandardWriter(opts), "", 0)
 }
 
 func (i *interceptLogger) StandardWriterIntercept(opts *StandardLoggerOptions) io.Writer {
+	return i.StandardWriter(opts)
+}
+
+func (i *interceptLogger) StandardWriter(opts *StandardLoggerOptions) io.Writer {
 	return &stdlogAdapter{
 		log:         i,
 		inferLevels: opts.InferLevels,

--- a/interceptlogger.go
+++ b/interceptlogger.go
@@ -127,13 +127,7 @@ func (i *interceptLogger) retrieveImplied(args ...interface{}) []interface{} {
 // This is used to create a subsystem specific Logger.
 // Registered sinks will subscribe to these messages as well.
 func (i *interceptLogger) Named(name string) Logger {
-	var sub interceptLogger
-
-	sub = *i
-
-	sub.Logger = i.Logger.Named(name)
-
-	return &sub
+	return i.NamedIntercept(name)
 }
 
 // Create a new sub-Logger with an explicit name. This ignores the current
@@ -141,13 +135,7 @@ func (i *interceptLogger) Named(name string) Logger {
 // within the normal hierarchy. Registered sinks will subscribe
 // to these messages as well.
 func (i *interceptLogger) ResetNamed(name string) Logger {
-	var sub interceptLogger
-
-	sub = *i
-
-	sub.Logger = i.Logger.ResetNamed(name)
-
-	return &sub
+	return i.ResetNamedIntercept(name)
 }
 
 // Create a new sub-Logger that a name decending from the current name.
@@ -157,9 +145,7 @@ func (i *interceptLogger) NamedIntercept(name string) InterceptLogger {
 	var sub interceptLogger
 
 	sub = *i
-
 	sub.Logger = i.Logger.Named(name)
-
 	return &sub
 }
 
@@ -171,9 +157,7 @@ func (i *interceptLogger) ResetNamedIntercept(name string) InterceptLogger {
 	var sub interceptLogger
 
 	sub = *i
-
 	sub.Logger = i.Logger.ResetNamed(name)
-
 	return &sub
 }
 

--- a/interceptlogger_test.go
+++ b/interceptlogger_test.go
@@ -237,7 +237,7 @@ func TestInterceptLogger(t *testing.T) {
 			Output: &buf,
 		})
 
-		standard := intercept.StandardLoggerIntercept(&StandardLoggerOptions{InferLevels: true})
+		standard := intercept.StandardLogger(&StandardLoggerOptions{InferLevels: true})
 
 		sink := NewSinkAdapter(&LoggerOptions{
 			Level:  Debug,

--- a/logger.go
+++ b/logger.go
@@ -271,10 +271,10 @@ type InterceptLogger interface {
 	// the current name as well.
 	ResetNamedIntercept(name string) InterceptLogger
 
-	// Return a value that conforms to the stdlib log.Logger interface
+	// Deprecated: use StandardLogger
 	StandardLoggerIntercept(opts *StandardLoggerOptions) *log.Logger
 
-	// Return a value that conforms to io.Writer, which can be passed into log.SetOutput()
+	// Deprecated: use StandardWriter
 	StandardWriterIntercept(opts *StandardLoggerOptions) io.Writer
 }
 


### PR DESCRIPTION
From #50

When I first read over the `go-hclog` godoc I was a little confused about the distinction between the Logger and InterceptLogger. I think a big part of that confusion was the number of methods involved. This PR helps reduce that number by removing extra interface methods, and making the implementation of others more explicitly a wrapper for the underlying interface.

