### PR TITLE
Fix color formatting of logs

### DIFF
--- a/colorize_unix.go
+++ b/colorize_unix.go
@@ -3,25 +3,20 @@
 package hclog
 
 import (
+	"os"
+
 	"github.com/mattn/go-isatty"
 )
 
-// setColorization will mutate the values of this logger
-// to approperately configure colorization options. It provides
-// a wrapper to the output stream on Windows systems.
-func (l *intLogger) setColorization(opts *LoggerOptions) {
-	switch opts.Color {
-	case ColorOff:
-		fallthrough
-	case ForceColor:
+func withColor(w *writer) {
+	switch w.color {
+	case ColorOff, ForceColor:
 		return
 	case AutoColor:
-		fi := l.checkWriterIsFile()
-		isUnixTerm := isatty.IsTerminal(fi.Fd())
-		isCygwinTerm := isatty.IsCygwinTerminal(fi.Fd())
-		isTerm := isUnixTerm || isCygwinTerm
-		if !isTerm {
-			l.writer.color = ColorOff
+		fd := os.Stdout.Fd()
+		if isatty.IsTerminal(fd) || isatty.IsCygwinTerminal(fd) {
+			return
 		}
+		w.color = ColorOff
 	}
 }

--- a/colorize_windows.go
+++ b/colorize_windows.go
@@ -6,28 +6,17 @@ import (
 	"os"
 
 	colorable "github.com/mattn/go-colorable"
-	"github.com/mattn/go-isatty"
 )
 
-// setColorization will mutate the values of this logger
-// to approperately configure colorization options. It provides
-// a wrapper to the output stream on Windows systems.
-func (l *intLogger) setColorization(opts *LoggerOptions) {
-	switch opts.Color {
+func withColor(w *writer) {
+	switch w.color {
 	case ColorOff:
 		return
-	case ForceColor:
-		fi := l.checkWriterIsFile()
-		l.writer.w = colorable.NewColorable(fi)
-	case AutoColor:
-		fi := l.checkWriterIsFile()
-		isUnixTerm := isatty.IsTerminal(os.Stdout.Fd())
-		isCygwinTerm := isatty.IsCygwinTerminal(os.Stdout.Fd())
-		isTerm := isUnixTerm || isCygwinTerm
-		if !isTerm {
-			l.writer.color = ColorOff
+	case ForceColor, AutoColor:
+		if fi, ok := w.w.(*os.File); ok {
+			w.w = colorable.NewColorable(fi)
 			return
 		}
-		l.writer.w = colorable.NewColorable(fi)
+		w.color = ColorOff
 	}
 }

--- a/go.mod
+++ b/go.mod
@@ -2,7 +2,6 @@ module github.com/hashicorp/go-hclog
 
 require (
 	github.com/davecgh/go-spew v1.1.1 // indirect
-	github.com/fatih/color v1.7.0
 	github.com/mattn/go-colorable v0.1.4
 	github.com/mattn/go-isatty v0.0.10
 	github.com/pmezard/go-difflib v1.0.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1,7 +1,5 @@
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
-github.com/fatih/color v1.7.0 h1:DkWD4oS2D8LGGgTQ6IvwJJXSL5Vp2ffcQg58nFV38Ys=
-github.com/fatih/color v1.7.0/go.mod h1:Zm6kSWBoL9eyXnKyktHP6abPY2pDugNf5KwzbycvMj4=
 github.com/mattn/go-colorable v0.1.4 h1:snbPLB8fVfU9iwbbo30TPtbLRzwWu6aJS6Xh4eaaviA=
 github.com/mattn/go-colorable v0.1.4/go.mod h1:U0ppj6V5qS13XJ6of8GYAs25YV2eR4EVcfRqFIhoBtE=
 github.com/mattn/go-isatty v0.0.8 h1:HLtExJ+uU2HOZ+wI0Tt5DtUDrx8yhUqDcp7fYERX4CE=

--- a/intlogger.go
+++ b/intlogger.go
@@ -16,8 +16,6 @@ import (
 	"sync"
 	"sync/atomic"
 	"time"
-
-	"github.com/fatih/color"
 )
 
 // TimeFormat to use for logging. This is a version of RFC3339 that contains
@@ -26,24 +24,6 @@ const TimeFormat = "2006-01-02T15:04:05.000Z0700"
 
 // errJsonUnsupportedTypeMsg is included in log json entries, if an arg cannot be serialized to json
 const errJsonUnsupportedTypeMsg = "logging contained values that don't serialize to json"
-
-var (
-	_levelToBracket = map[Level]string{
-		Debug: "[DEBUG]",
-		Trace: "[TRACE]",
-		Info:  "[INFO] ",
-		Warn:  "[WARN] ",
-		Error: "[ERROR]",
-	}
-
-	_levelToColor = map[Level]*color.Color{
-		Debug: color.New(color.FgHiWhite),
-		Trace: color.New(color.FgHiGreen),
-		Info:  color.New(color.FgHiBlue),
-		Warn:  color.New(color.FgHiYellow),
-		Error: color.New(color.FgHiRed),
-	}
-)
 
 // Make sure that intLogger is a Logger
 var _ Logger = &intLogger{}
@@ -310,6 +290,14 @@ func (l *intLogger) logPlain(t time.Time, name string, level Level, msg string, 
 		l.writer.WriteString(string(stacktrace))
 		l.writer.WriteString("\n")
 	}
+}
+
+var _levelToBracket = map[Level]string{
+	Debug: "[DEBUG]",
+	Trace: "[TRACE]",
+	Info:  "[INFO] ",
+	Warn:  "[WARN] ",
+	Error: "[ERROR]",
 }
 
 func (l *intLogger) renderSlice(v reflect.Value) string {

--- a/intlogger.go
+++ b/intlogger.go
@@ -8,7 +8,6 @@ import (
 	"fmt"
 	"io"
 	"log"
-	"os"
 	"reflect"
 	"runtime"
 	"sort"
@@ -109,8 +108,6 @@ func newLogger(opts *LoggerOptions) *intLogger {
 		level:      new(int32),
 		exclude:    opts.Exclude,
 	}
-
-	l.setColorization(opts)
 
 	if opts.DisableTime {
 		l.timeFormat = ""
@@ -607,7 +604,6 @@ func (l *intLogger) ResetOutputWithFlush(opts *LoggerOptions, flushable Flushabl
 
 func (l *intLogger) resetOutput(opts *LoggerOptions) error {
 	l.writer = newWriter(opts.Output, opts.Color)
-	l.setColorization(opts)
 	return nil
 }
 
@@ -634,16 +630,6 @@ func (l *intLogger) StandardWriter(opts *StandardLoggerOptions) io.Writer {
 		inferLevels: opts.InferLevels,
 		forceLevel:  opts.ForceLevel,
 	}
-}
-
-// checks if the underlying io.Writer is a file, and
-// panics if not. For use by colorization.
-func (l *intLogger) checkWriterIsFile() *os.File {
-	fi, ok := l.writer.w.(*os.File)
-	if !ok {
-		panic("Cannot enable coloring of non-file Writers")
-	}
-	return fi
 }
 
 // Accept implements the SinkAdapter interface

--- a/logger_test.go
+++ b/logger_test.go
@@ -762,3 +762,16 @@ func BenchmarkLogger(b *testing.B) {
 		}
 	})
 }
+
+func TestLogger_WithColor(t *testing.T) {
+	buf := new(bytes.Buffer)
+	logger := New(&LoggerOptions{
+		Output:     buf,
+		Color:      ForceColor,
+		TimeFormat: "none",
+	})
+
+	logger.Warn("this message", "key", "value")
+	expected := "\x1b[38;5;226mnone [WARN]  this message: key=value\n\x1b[0m"
+	require.Equal(t, expected, buf.String())
+}

--- a/writer.go
+++ b/writer.go
@@ -11,8 +11,10 @@ type writer struct {
 	color ColorOption
 }
 
-func newWriter(w io.Writer, color ColorOption) *writer {
-	return &writer{w: w, color: color}
+func newWriter(out io.Writer, color ColorOption) *writer {
+	w := &writer{w: out, color: color}
+	withColor(w)
+	return w
 }
 
 func (w *writer) Flush(level Level) (err error) {


### PR DESCRIPTION
Previously `go-hclog` assumes the writer would always be an `os.File`, but it is very common for the `os.Stdout` file to be wrapped with other io.Writers, even if the logs eventually get written to an `os.File`. This requirement was artificial because only windows requires the writer to be a file.

This PR removes the requirement for the writer to be a file, and instead checks `os.Stdout`. It removes a panic in both unix and windows. Now instead of the panic unix will always print color codes if forced, and windows will disable color if it is unable to cast the writer to an `os.File`.

Also removes the `github.com/fatih/color` dependency. This project has been archived, and doesn't really support 8bit (or 24bit) colors, which are pretty commonly supported by most terminals. The dependency was replaced by a single function.

The color codes were also updated slightly. Instead of the hi-intensity colors use the color codes for 8bit colors. This is easy enough to change back, but I found using hi-intensity colors didn't work very well in my terminal.