### PR TITLE
Cleanup timestamp logic

### DIFF
--- a/logger_test.go
+++ b/logger_test.go
@@ -550,6 +550,33 @@ func TestLogger_JSON(t *testing.T) {
 		assert.Equal(t, "testing is fun", raw["why"])
 	})
 
+	t.Run("use a different time format", func(t *testing.T) {
+		var buf bytes.Buffer
+
+		logger := New(&LoggerOptions{
+			Name:       "test",
+			Output:     &buf,
+			JSONFormat: true,
+			TimeFormat: time.Kitchen,
+		})
+
+		logger.Info("Lacatan banana")
+
+		b := buf.Bytes()
+
+		var raw map[string]interface{}
+		if err := json.Unmarshal(b, &raw); err != nil {
+			t.Fatal(err)
+		}
+
+		val, ok := raw["@timestamp"]
+		if !ok {
+			t.Fatal("missing '@timestamp' key")
+		}
+
+		assert.Equal(t, val, time.Now().Format(time.Kitchen))
+	})
+
 	t.Run("respects DisableTime", func(t *testing.T) {
 		var buf bytes.Buffer
 		logger := New(&LoggerOptions{


### PR DESCRIPTION
fix: make JSON formatter respect the value of TimeFormat
Plus simplify the logic behind DisableTime

NOTE: This branch is off https://github.com/marco-m/go-hclog/tree/fix-disabletime and should be rebased on master once #75 is merged. 