### PR TITLE
update callerOffset while use StandardWriter

### DIFF
--- a/intlogger.go
+++ b/intlogger.go
@@ -635,8 +635,21 @@ func (l *intLogger) StandardLogger(opts *StandardLoggerOptions) *log.Logger {
 }
 
 func (l *intLogger) StandardWriter(opts *StandardLoggerOptions) io.Writer {
+        newLog := &intLogger{
+		json:              l.json,
+		name:              l.name,
+		timeFormat:        l.timeFormat,
+		mutex:             l.mutex,
+		writer:            l.writer,
+		level:             l.level,
+		exclude:           l.exclude,
+		independentLevels: l.independentLevels,
+	}
+	if l.callerOffset > 0 {
+		newLog.callerOffset = l.callerOffset + 4
+	}
 	return &stdlogAdapter{
-		log:         l,
+		log:         newLog,
 		inferLevels: opts.InferLevels,
 		forceLevel:  opts.ForceLevel,
 	}

--- a/intlogger.go
+++ b/intlogger.go
@@ -635,16 +635,7 @@ func (l *intLogger) StandardLogger(opts *StandardLoggerOptions) *log.Logger {
 }
 
 func (l *intLogger) StandardWriter(opts *StandardLoggerOptions) io.Writer {
-        newLog := &intLogger{
-		json:              l.json,
-		name:              l.name,
-		timeFormat:        l.timeFormat,
-		mutex:             l.mutex,
-		writer:            l.writer,
-		level:             l.level,
-		exclude:           l.exclude,
-		independentLevels: l.independentLevels,
-	}
+        newLog := *l
 	if l.callerOffset > 0 {
 		// the stack is
 		// logger.printf() -> l.Output() ->l.out.writer(hclog:stdlogAdaptor.write) -> hclog:stdlogAdaptor.dispatch()

--- a/intlogger.go
+++ b/intlogger.go
@@ -646,6 +646,9 @@ func (l *intLogger) StandardWriter(opts *StandardLoggerOptions) io.Writer {
 		independentLevels: l.independentLevels,
 	}
 	if l.callerOffset > 0 {
+		// the stack is
+		// logger.printf() -> l.Output() ->l.out.writer(hclog:stdlogAdaptor.write) -> hclog:stdlogAdaptor.dispatch()
+		// So plus 4.
 		newLog.callerOffset = l.callerOffset + 4
 	}
 	return &stdlogAdapter{

--- a/intlogger.go
+++ b/intlogger.go
@@ -635,7 +635,7 @@ func (l *intLogger) StandardLogger(opts *StandardLoggerOptions) *log.Logger {
 }
 
 func (l *intLogger) StandardWriter(opts *StandardLoggerOptions) io.Writer {
-        newLog := *l
+      newLog := *l
 	if l.callerOffset > 0 {
 		// the stack is
 		// logger.printf() -> l.Output() ->l.out.writer(hclog:stdlogAdaptor.write) -> hclog:stdlogAdaptor.dispatch()

--- a/intlogger.go
+++ b/intlogger.go
@@ -643,7 +643,7 @@ func (l *intLogger) StandardWriter(opts *StandardLoggerOptions) io.Writer {
 		newLog.callerOffset = l.callerOffset + 4
 	}
 	return &stdlogAdapter{
-		log:         newLog,
+		log:         &newLog,
 		inferLevels: opts.InferLevels,
 		forceLevel:  opts.ForceLevel,
 	}


### PR DESCRIPTION
fix https://github.com/hashicorp/go-hclog/issues/82 again.
Though #77 is related to #82, The problem was not fixed when I use intLoger.StandardLogger.

I had opened a PR for consul-esm to use hclog(https://github.com/hashicorp/consul-esm/pull/97).
It's depend on go-hclog(v0.15.0), which not include #77.
But my local use https://github.com/varnson/go-hclog/releases/tag/v0.15.5, which include #77, and I found the problem was not fixed.

Now I use https://github.com/varnson/go-hclog/releases/tag/v0.15.7 and it works well.

