### PR TITLE
Add an AdditionalLocationOffset option to LoggerOptions.

### DIFF
--- a/intlogger.go
+++ b/intlogger.go
@@ -124,7 +124,7 @@ func newLogger(opts *LoggerOptions) *intLogger {
 		independentLevels: opts.IndependentLevels,
 	}
 	if opts.IncludeLocation {
-		l.callerOffset = offsetIntLogger
+		l.callerOffset = offsetIntLogger + opts.AdditionalLocationOffset
 	}
 
 	if l.json {

--- a/logger.go
+++ b/logger.go
@@ -235,6 +235,10 @@ type LoggerOptions struct {
 	// Include file and line information in each log line
 	IncludeLocation bool
 
+	// AdditionalLocationOffset is the number of additional stack levels to skip
+	// when finding the file and line information for the log line
+	AdditionalLocationOffset int
+
 	// The time format to use instead of the default
 	TimeFormat string
 

--- a/stdlog_test.go
+++ b/stdlog_test.go
@@ -181,3 +181,32 @@ func TestFromStandardLogger(t *testing.T) {
 	prefix := "test-stdlib-log "
 	require.Equal(t, prefix, actual[:16])
 }
+
+func TestFromStandardLogger_helper(t *testing.T) {
+	var buf bytes.Buffer
+
+	sl := log.New(&buf, "test-stdlib-log ", log.Ltime)
+
+	hl := FromStandardLogger(sl, &LoggerOptions{
+		Name:             "hclog-inner",
+		IncludeLocation:  true,
+		AdditionalLocationOffset: 1,
+	})
+
+	helper := func() {
+		hl.Info("this is a test", "name", "tester", "count", 1)
+	}
+
+	helper()
+	_, file, line, ok := runtime.Caller(0)
+	require.True(t, ok)
+
+	actual := buf.String()
+	suffix := fmt.Sprintf(
+		"[INFO]  go-hclog/%s:%d: hclog-inner: this is a test: name=tester count=1\n",
+		filepath.Base(file), line-1)
+	require.Equal(t, suffix, actual[25:])
+
+	prefix := "test-stdlib-log "
+	require.Equal(t, prefix, actual[:16])
+}


### PR DESCRIPTION
Add the ability for wrappers of hclog to have the file and line number
point to their caller, instead of the wrappers, by specifying additional
offsets for the callstack when creating a logger.