### PR TITLE
add Quote type to enable safe concise output of untrusted strings

### DIFF
--- a/intlogger.go
+++ b/intlogger.go
@@ -295,6 +295,9 @@ func (l *intLogger) logPlain(t time.Time, name string, level Level, msg string, 
 				continue FOR
 			case Format:
 				val = fmt.Sprintf(st[0].(string), st[1:]...)
+			case Quote:
+				raw = true
+				val = strconv.Quote(string(st))
 			default:
 				v := reflect.ValueOf(st)
 				if v.Kind() == reflect.Slice {

--- a/logger.go
+++ b/logger.go
@@ -67,6 +67,12 @@ type Octal int
 // text output. For example: L.Info("bits", Binary(17))
 type Binary int
 
+// A simple shortcut to format strings with Go quoting. Control and
+// non-printable characters will be escaped with their backslash equivalents in
+// output. Intended for untrusted or multiline strings which should be logged
+// as concisely as possible.
+type Quote string
+
 // ColorOption expresses how the output should be colored, if at all.
 type ColorOption uint8
 


### PR DESCRIPTION
Output from hashicorp/nomad#10858 using hclog v0.14.1 (double double quotes):

```
2021-07-06T10:06:01.590-0700 [WARN] ... task=redis health=critical output=""This is the output for state 2\n""
```

Output using hclog v0.16.1 (breaks naive 1-line-per-log parsers):

```
2021-07-06T15:41:34.112-0700 [WARN] ... task=redis health=warning
  output=
  | This is the output for state 1
```

Output using this PR:

```
2021-07-06T15:42:28.192-0700 [WARN] ... task=redis health=warning output="This is the output for state 1\n"
```