### PR TITLE
Set `raw=true` when special casing empty strings

### DIFF
--- a/intlogger.go
+++ b/intlogger.go
@@ -281,6 +281,7 @@ func (l *intLogger) logPlain(t time.Time, name string, level Level, msg string, 
 				val = st
 				if st == "" {
 					val = `""`
+					raw = true
 				}
 			case int:
 				val = strconv.FormatInt(int64(st), 10)

--- a/logger_test.go
+++ b/logger_test.go
@@ -120,6 +120,23 @@ func TestLogger(t *testing.T) {
 		assert.Equal(t, `[INFO]  test: this is test: who=programmer why="this is \"quoted\""`+"\n", rest)
 	})
 
+	t.Run("prints empty double quotes for empty strings", func(t *testing.T) {
+		var buf bytes.Buffer
+
+		logger := New(&LoggerOptions{
+			Name:   "test",
+			Output: &buf,
+		})
+
+		logger.Info("this is test", "who", "programmer", "why", ``)
+
+		str := buf.String()
+		dataIdx := strings.IndexByte(str, ' ')
+		rest := str[dataIdx+1:]
+
+		assert.Equal(t, `[INFO]  test: this is test: who=programmer why=""`+"\n", rest)
+	})
+
 	t.Run("quotes when there are nonprintable sequences in a value", func(t *testing.T) {
 		var buf bytes.Buffer
 


### PR DESCRIPTION
Found that empty strings are being rendered as `foo="\"\"'`. Added `raw=true` to the special case for them and that appears to resolve the issue.  Added a test to capture the situation.