### PR TITLE
Refactor colorization: faster, and one less dependency

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -2,7 +2,6 @@ module github.com/hashicorp/go-hclog
 
 require (
 	github.com/davecgh/go-spew v1.1.1 // indirect
-	github.com/fatih/color v1.7.0
 	github.com/mattn/go-colorable v0.1.4
 	github.com/mattn/go-isatty v0.0.10
 	github.com/pmezard/go-difflib v1.0.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1,7 +1,5 @@
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
-github.com/fatih/color v1.7.0 h1:DkWD4oS2D8LGGgTQ6IvwJJXSL5Vp2ffcQg58nFV38Ys=
-github.com/fatih/color v1.7.0/go.mod h1:Zm6kSWBoL9eyXnKyktHP6abPY2pDugNf5KwzbycvMj4=
 github.com/mattn/go-colorable v0.1.4 h1:snbPLB8fVfU9iwbbo30TPtbLRzwWu6aJS6Xh4eaaviA=
 github.com/mattn/go-colorable v0.1.4/go.mod h1:U0ppj6V5qS13XJ6of8GYAs25YV2eR4EVcfRqFIhoBtE=
 github.com/mattn/go-isatty v0.0.8 h1:HLtExJ+uU2HOZ+wI0Tt5DtUDrx8yhUqDcp7fYERX4CE=

--- a/intlogger.go
+++ b/intlogger.go
@@ -35,9 +35,10 @@ const errJsonUnsupportedTypeMsg = "logging contained values that don't serialize
 type colorize = func([]byte) []byte
 
 func colorizer(attr color.Attribute) colorize {
-	c := "\033[" + fmt.Sprint(int(attr)) + "m%s\033[0m"
+	before := "\033[" + fmt.Sprint(int(attr)) + "m"
+	const after = "\033[0m"
 	return func(b []byte) []byte {
-		return []byte(fmt.Sprintf(c, b))
+		return append(append(append(make([]byte, 0, 5+len(b)+4), before...), b...), after...)
 	}
 }
 

--- a/intlogger.go
+++ b/intlogger.go
@@ -35,7 +35,7 @@ const errJsonUnsupportedTypeMsg = "logging contained values that don't serialize
 type colorize = func([]byte) []byte
 
 func colorizer(attr color.Attribute) colorize {
-	c := color.New(attr).Sprint("%" + "s")
+	c := "\033[" + fmt.Sprint(int(attr)) + "m%s\033[0m"
 	return func(b []byte) []byte {
 		return []byte(fmt.Sprintf(c, b))
 	}

--- a/intlogger.go
+++ b/intlogger.go
@@ -35,9 +35,9 @@ const errJsonUnsupportedTypeMsg = "logging contained values that don't serialize
 type colorize = func([]byte) []byte
 
 func colorizer(attr color.Attribute) colorize {
-	c := color.New(attr)
+	c := color.New(attr).Sprint("%" + "s")
 	return func(b []byte) []byte {
-		return []byte(c.Sprintf("%s", b))
+		return []byte(fmt.Sprintf(c, b))
 	}
 }
 

--- a/intlogger.go
+++ b/intlogger.go
@@ -17,8 +17,6 @@ import (
 	"sync"
 	"sync/atomic"
 	"time"
-
-	"github.com/fatih/color"
 )
 
 // TimeFormat is the time format to use for plain (non-JSON) output.
@@ -34,8 +32,8 @@ const errJsonUnsupportedTypeMsg = "logging contained values that don't serialize
 
 type colorize = func([]byte) []byte
 
-func colorizer(attr color.Attribute) colorize {
-	before := "\033[" + fmt.Sprint(int(attr)) + "m"
+func colorizer(color string) colorize {
+	before := "\033[" + color + "m"
 	const after = "\033[0m"
 	return func(b []byte) []byte {
 		return append(append(append(make([]byte, 0, 5+len(b)+4), before...), b...), after...)
@@ -52,11 +50,11 @@ var (
 	}
 
 	_levelToColor = map[Level]colorize{
-		Debug: colorizer(color.FgHiWhite),
-		Trace: colorizer(color.FgHiGreen),
-		Info:  colorizer(color.FgHiBlue),
-		Warn:  colorizer(color.FgHiYellow),
-		Error: colorizer(color.FgHiRed),
+		Debug: colorizer("97"), // HiWhite
+		Trace: colorizer("92"), // HiGreen
+		Info:  colorizer("94"), // HiBlue
+		Warn:  colorizer("93"), // HiYellow
+		Error: colorizer("91"), // HiRed
 	}
 )
 

--- a/intlogger.go
+++ b/intlogger.go
@@ -30,9 +30,7 @@ const TimeFormatJSON = "2006-01-02T15:04:05.000000Z07:00"
 // errJsonUnsupportedTypeMsg is included in log json entries, if an arg cannot be serialized to json
 const errJsonUnsupportedTypeMsg = "logging contained values that don't serialize to json"
 
-type colorize = func([]byte) []byte
-
-func colorizer(color string) colorize {
+func colorizer(color string) func([]byte) []byte {
 	before := "\033[" + color + "m"
 	const after = "\033[0m"
 	return func(b []byte) []byte {
@@ -49,7 +47,7 @@ var (
 		Error: "[ERROR]",
 	}
 
-	_levelToColor = map[Level]colorize{
+	_levelToColor = map[Level]func([]byte) []byte{
 		Debug: colorizer("97"), // HiWhite
 		Trace: colorizer("92"), // HiGreen
 		Info:  colorizer("94"), // HiBlue
@@ -57,6 +55,10 @@ var (
 		Error: colorizer("91"), // HiRed
 	}
 )
+
+func colorize(level Level, b []byte) []byte {
+	return _levelToColor[level](b)
+}
 
 // Make sure that intLogger is a Logger
 var _ Logger = &intLogger{}

--- a/intlogger.go
+++ b/intlogger.go
@@ -32,6 +32,15 @@ const TimeFormatJSON = "2006-01-02T15:04:05.000000Z07:00"
 // errJsonUnsupportedTypeMsg is included in log json entries, if an arg cannot be serialized to json
 const errJsonUnsupportedTypeMsg = "logging contained values that don't serialize to json"
 
+type colorize = func([]byte) []byte
+
+func colorizer(attr color.Attribute) colorize {
+	c := color.New(attr)
+	return func(b []byte) []byte {
+		return []byte(c.Sprintf("%s", b))
+	}
+}
+
 var (
 	_levelToBracket = map[Level]string{
 		Debug: "[DEBUG]",
@@ -41,12 +50,12 @@ var (
 		Error: "[ERROR]",
 	}
 
-	_levelToColor = map[Level]*color.Color{
-		Debug: color.New(color.FgHiWhite),
-		Trace: color.New(color.FgHiGreen),
-		Info:  color.New(color.FgHiBlue),
-		Warn:  color.New(color.FgHiYellow),
-		Error: color.New(color.FgHiRed),
+	_levelToColor = map[Level]colorize{
+		Debug: colorizer(color.FgHiWhite),
+		Trace: colorizer(color.FgHiGreen),
+		Info:  colorizer(color.FgHiBlue),
+		Warn:  colorizer(color.FgHiYellow),
+		Error: colorizer(color.FgHiRed),
 	}
 )
 

--- a/logger_test.go
+++ b/logger_test.go
@@ -232,6 +232,34 @@ func TestLogger(t *testing.T) {
 		assert.Equal(t, "[INFO]  sublogger: this is test\n", rest)
 	})
 
+	t.Run("colorize", func(t *testing.T) {
+		var buf bytes.Buffer
+
+		logger := New(&LoggerOptions{
+			// No name!
+			Output:     &buf,
+			Level:      Trace,
+			Color:      ForceColor,
+			TimeFormat: "<time>",
+		})
+
+		logger.Trace("trace")
+		logger.Debug("debug")
+		logger.Info("info")
+		logger.Warn("warn")
+		logger.Error("error")
+		str := buf.String()
+
+		assert.Equal(t, ""+
+			"\033[92m<time> [TRACE] trace\n\033[0m"+
+			"\033[97m<time> [DEBUG] debug\n\033[0m"+
+			"\033[94m<time> [INFO]  info\n\033[0m"+
+			"\033[93m<time> [WARN]  warn\n\033[0m"+
+			"\033[91m<time> [ERROR] error\n\033[0m",
+			str,
+		)
+	})
+
 	t.Run("use a different time format", func(t *testing.T) {
 		var buf bytes.Buffer
 

--- a/writer.go
+++ b/writer.go
@@ -19,7 +19,7 @@ func (w *writer) Flush(level Level) (err error) {
 	var unwritten = w.b.Bytes()
 
 	if w.color != ColorOff {
-		unwritten = _levelToColor[level](unwritten)
+		unwritten = colorize(level, unwritten)
 	}
 
 	if lw, ok := w.w.(LevelWriter); ok {

--- a/writer.go
+++ b/writer.go
@@ -19,8 +19,7 @@ func (w *writer) Flush(level Level) (err error) {
 	var unwritten = w.b.Bytes()
 
 	if w.color != ColorOff {
-		color := _levelToColor[level]
-		unwritten = []byte(color.Sprintf("%s", unwritten))
+		unwritten = _levelToColor[level](unwritten)
 	}
 
 	if lw, ok := w.w.(LevelWriter); ok {


### PR DESCRIPTION
Refactor colorization (which uses ANSI sequences):
* add non-regression test for colorization 
* faster: drop multiple calls to `fmt.Sprintf` per log message
* drop dependency on `github.com/fatih/color`