### PR TITLE
Add ability to only colorize the header, not the whole log message

### DIFF
--- a/colorize_unix.go
+++ b/colorize_unix.go
@@ -1,3 +1,4 @@
+//go:build !windows
 // +build !windows
 
 package hclog
@@ -21,6 +22,7 @@ func (l *intLogger) setColorization(opts *LoggerOptions) {
 		isCygwinTerm := isatty.IsCygwinTerminal(fi.Fd())
 		isTerm := isUnixTerm || isCygwinTerm
 		if !isTerm {
+			l.headerColor = ColorOff
 			l.writer.color = ColorOff
 		}
 	}

--- a/colorize_windows.go
+++ b/colorize_windows.go
@@ -1,3 +1,4 @@
+//go:build windows
 // +build windows
 
 package hclog
@@ -26,8 +27,12 @@ func (l *intLogger) setColorization(opts *LoggerOptions) {
 		isTerm := isUnixTerm || isCygwinTerm
 		if !isTerm {
 			l.writer.color = ColorOff
+			l.headerColor = ColorOff
 			return
 		}
-		l.writer.w = colorable.NewColorable(fi)
+
+		if l.headerColor == ColorOff {
+			l.writer.w = colorable.NewColorable(fi)
+		}
 	}
 }

--- a/logger.go
+++ b/logger.go
@@ -271,6 +271,9 @@ type LoggerOptions struct {
 	// are concretely instances of *os.File.
 	Color ColorOption
 
+	// Only color the header, not the body. This can help with readability of long messages.
+	ColorHeaderOnly bool
+
 	// A function which is called with the log information and if it returns true the value
 	// should not be logged.
 	// This is useful when interacting with a system that you wish to suppress the log


### PR DESCRIPTION
This improves the readability of colored messages by only colorizing the level header rather than the whole message. On many terminals, some of the colors are hard to read for large segments of text. Colorizing just the header make it possible to easily visually scan the log output while preserving the readability of the log message itself.

Here is a random snippit showing the visual effect of this option:
<img width="984" alt="CleanShot 2022-02-24 at 14 38 17@2x" src="https://user-images.githubusercontent.com/7/155619275-3a14bb00-11ea-46ed-8e44-050613cb3ee2.png">

