### PR TITLE
Remove github.com/stretchr/testify dependency

### DIFF
--- a/assert_test.go
+++ b/assert_test.go
@@ -1,0 +1,153 @@
+package hclog
+
+import (
+	"strings"
+	"testing"
+)
+
+// assertContains will return a test error if the actual string does not
+// contain the expected string. This is used in place of requiring a dependency
+// such as testify.
+func assertContains(t *testing.T, expected string, actual string) bool {
+	t.Helper()
+
+	if strings.Contains(actual, expected) {
+		t.Errorf("Does not contain: \n"+
+			"expected: %s\n"+
+			"actual  : %s", expected, actual)
+		return false
+	}
+
+	return true
+}
+
+// assertEmpty will return a test error if the actual string is not empty.
+// This is used in place of requiring a dependency such as testify.
+func assertEmpty(t *testing.T, actual string) bool {
+	t.Helper()
+
+	if actual != "" {
+		t.Errorf("Should be empty, but was %s", actual)
+		return false
+	}
+
+	return true
+}
+
+// assertEqual will return a test error if the expected string does not
+// equal the actual string. This is used in place of requiring a dependency
+// such as testify.
+func assertEqual(t *testing.T, expected string, actual string) bool {
+	t.Helper()
+
+	if expected != actual {
+		t.Errorf("Not equal: \n"+
+			"expected: %s\n"+
+			"actual  : %s", expected, actual)
+		return false
+	}
+
+	return true
+}
+
+// assertFalse will return a test error if the actual bool is true.
+// This is used in place of requiring a dependency such as testify.
+func assertFalse(t *testing.T, actual bool) bool {
+	t.Helper()
+
+	if actual {
+		t.Error("Should be false")
+		return false
+	}
+
+	return true
+}
+
+// assertNoError will return a test error if the error is not nil.
+// This is used in place of requiring a dependency such as testify.
+func assertNoError(t *testing.T, actual error) bool {
+	t.Helper()
+
+	if actual != nil {
+		t.Errorf("Expected no error, but was %s", actual)
+		return false
+	}
+
+	return true
+}
+
+// assertNotNil will return a test error if the actual is not nil.
+// This is used in place of requiring a dependency such as testify.
+func assertNotNil(t *testing.T, actual interface{}) bool {
+	t.Helper()
+
+	if actual == nil {
+		t.Error("Expected value not to be nil.")
+		return false
+	}
+
+	return true
+}
+
+// assertTrue will return a test error if the actual bool is false.
+// This is used in place of requiring a dependency such as testify.
+func assertTrue(t *testing.T, actual bool) bool {
+	t.Helper()
+
+	if !actual {
+		t.Error("Should be true")
+		return false
+	}
+
+	return true
+}
+
+// requireContains will immediately fail the test if the actual string does not
+// contain the expected string. This is used in place of requiring a dependency
+// such as testify.
+func requireContains(t *testing.T, expected string, actual string) {
+	t.Helper()
+
+	if assertContains(t, expected, actual) {
+		return
+	}
+
+	t.FailNow()
+}
+
+// requireEqual will immediately fail the test if the expected string does not
+// equal the actual string. This is used in place of requiring a dependency
+// such as testify.
+func requireEqual(t *testing.T, expected string, actual string) {
+	t.Helper()
+
+	if assertEqual(t, expected, actual) {
+		return
+	}
+
+	t.FailNow()
+}
+
+// requireNotNil will immediately fail the test if the actual is not nil.
+// This is used in place of requiring a dependency such as testify.
+func requireNotNil(t *testing.T, actual interface{}) {
+	t.Helper()
+
+	if assertNotNil(t, actual) {
+		return
+	}
+
+	t.FailNow()
+}
+
+// requireTrue will immediately fail the test if the actual bool is false.
+// This is used in place of requiring a dependency such as testify.
+func requireTrue(t *testing.T, actual bool) {
+	t.Helper()
+
+	if assertTrue(t, actual) {
+		return
+	}
+
+	t.FailNow()
+}

--- a/context_test.go
+++ b/context_test.go
@@ -4,18 +4,20 @@ import (
 	"bytes"
 	"context"
 	"testing"
-
-	"github.com/stretchr/testify/require"
 )
 
 func TestContext_simpleLogger(t *testing.T) {
 	l := L()
 	ctx := WithContext(context.Background(), l)
-	require.Equal(t, l, FromContext(ctx))
+	if l != FromContext(ctx) {
+		t.Fatalf("expected equal")
+	}
 }
 
 func TestContext_empty(t *testing.T) {
-	require.Equal(t, L(), FromContext(context.Background()))
+	if L() != FromContext(context.Background()) {
+		t.Fatalf("expected equal")
+	}
 }
 
 func TestContext_fields(t *testing.T) {
@@ -28,9 +30,9 @@ func TestContext_fields(t *testing.T) {
 	// Insert the logger with fields
 	ctx := WithContext(context.Background(), l, "hello", "world")
 	l = FromContext(ctx)
-	require.NotNil(t, l)
+	requireNotNil(t, l)
 
 	// Log something so we can test the output that the field is there
 	l.Debug("test")
-	require.Contains(t, buf.String(), "hello")
+	requireContains(t, buf.String(), "hello")
 }

--- a/exclude_test.go
+++ b/exclude_test.go
@@ -3,8 +3,6 @@ package hclog
 import (
 	"regexp"
 	"testing"
-
-	"github.com/stretchr/testify/assert"
 )
 
 func TestExclude(t *testing.T) {
@@ -13,19 +11,19 @@ func TestExclude(t *testing.T) {
 		em.Add("foo")
 		em.Add("bar")
 
-		assert.True(t, em.Exclude(Info, "foo"))
-		assert.True(t, em.Exclude(Info, "bar"))
-		assert.False(t, em.Exclude(Info, "qux"))
-		assert.False(t, em.Exclude(Info, "foo qux"))
-		assert.False(t, em.Exclude(Info, "qux bar"))
+		assertTrue(t, em.Exclude(Info, "foo"))
+		assertTrue(t, em.Exclude(Info, "bar"))
+		assertFalse(t, em.Exclude(Info, "qux"))
+		assertFalse(t, em.Exclude(Info, "foo qux"))
+		assertFalse(t, em.Exclude(Info, "qux bar"))
 	})
 
 	t.Run("excludes by prefix", func(t *testing.T) {
 		ebp := ExcludeByPrefix("foo: ")
 
-		assert.True(t, ebp.Exclude(Info, "foo: rocks"))
-		assert.False(t, ebp.Exclude(Info, "foo"))
-		assert.False(t, ebp.Exclude(Info, "qux foo: bar"))
+		assertTrue(t, ebp.Exclude(Info, "foo: rocks"))
+		assertFalse(t, ebp.Exclude(Info, "foo"))
+		assertFalse(t, ebp.Exclude(Info, "qux foo: bar"))
 	})
 
 	t.Run("exclude by regexp", func(t *testing.T) {
@@ -33,11 +31,11 @@ func TestExclude(t *testing.T) {
 			Regexp: regexp.MustCompile("(foo|bar)"),
 		}
 
-		assert.True(t, ebr.Exclude(Info, "foo"))
-		assert.True(t, ebr.Exclude(Info, "bar"))
-		assert.True(t, ebr.Exclude(Info, "foo qux"))
-		assert.True(t, ebr.Exclude(Info, "qux bar"))
-		assert.False(t, ebr.Exclude(Info, "qux"))
+		assertTrue(t, ebr.Exclude(Info, "foo"))
+		assertTrue(t, ebr.Exclude(Info, "bar"))
+		assertTrue(t, ebr.Exclude(Info, "foo qux"))
+		assertTrue(t, ebr.Exclude(Info, "qux bar"))
+		assertFalse(t, ebr.Exclude(Info, "qux"))
 	})
 
 	t.Run("excludes many funcs", func(t *testing.T) {
@@ -46,10 +44,10 @@ func TestExclude(t *testing.T) {
 			ExcludeByPrefix("bar: ").Exclude,
 		}
 
-		assert.True(t, ef.Exclude(Info, "foo: rocks"))
-		assert.True(t, ef.Exclude(Info, "bar: rocks"))
-		assert.False(t, ef.Exclude(Info, "foo"))
-		assert.False(t, ef.Exclude(Info, "qux foo: bar"))
+		assertTrue(t, ef.Exclude(Info, "foo: rocks"))
+		assertTrue(t, ef.Exclude(Info, "bar: rocks"))
+		assertFalse(t, ef.Exclude(Info, "foo"))
+		assertFalse(t, ef.Exclude(Info, "qux foo: bar"))
 
 	})
 }

--- a/go.mod
+++ b/go.mod
@@ -1,12 +1,9 @@
 module github.com/hashicorp/go-hclog
 
 require (
-	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/fatih/color v1.13.0
 	github.com/mattn/go-colorable v0.1.12
 	github.com/mattn/go-isatty v0.0.14
-	github.com/pmezard/go-difflib v1.0.0 // indirect
-	github.com/stretchr/testify v1.2.2
 	golang.org/x/sys v0.0.0-20220503163025-988cb79eb6c6 // indirect
 )
 

--- a/go.sum
+++ b/go.sum
@@ -1,5 +1,3 @@
-github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
-github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/fatih/color v1.13.0 h1:8LOYc1KYPPmyKMuN8QV2DNRWNbLo6LZ0iLs8+mlH53w=
 github.com/fatih/color v1.13.0/go.mod h1:kLAiJbzzSOZDVNGyDpeOxJ47H46qBXwg5ILebYFFOfk=
 github.com/mattn/go-colorable v0.1.9/go.mod h1:u6P/XSegPjTcexA+o6vUJrdnUu04hMope9wVRipJSqc=
@@ -8,10 +6,6 @@ github.com/mattn/go-colorable v0.1.12/go.mod h1:u5H1YNBxpqRaxsYJYSkiCWKzEfiAb1Gb
 github.com/mattn/go-isatty v0.0.12/go.mod h1:cbi8OIDigv2wuxKPP5vlRcQ1OAZbq2CE4Kysco4FUpU=
 github.com/mattn/go-isatty v0.0.14 h1:yVuAays6BHfxijgZPzw+3Zlu5yQgKGP2/hcQbHb7S9Y=
 github.com/mattn/go-isatty v0.0.14/go.mod h1:7GGIvUiUoEMVVmxf/4nioHXj79iQHKdU27kJ6hsGG94=
-github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
-github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
-github.com/stretchr/testify v1.2.2 h1:bSDNvY7ZPG5RlJ8otE/7V6gMiyenm9RtJ7IUVIAoJ1w=
-github.com/stretchr/testify v1.2.2/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXfy6kDkUVs=
 golang.org/x/sys v0.0.0-20200116001909-b77594299b42/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20200223170610-d5e6a3e2c0ae/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20210630005230-0f9fa26af87c/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=

--- a/interceptlogger_test.go
+++ b/interceptlogger_test.go
@@ -7,9 +7,6 @@ import (
 	"runtime"
 	"strings"
 	"testing"
-
-	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
 )
 
 func TestInterceptLogger(t *testing.T) {
@@ -36,7 +33,7 @@ func TestInterceptLogger(t *testing.T) {
 		dataIdx := strings.IndexByte(str, ' ')
 		rest := str[dataIdx+1:]
 
-		assert.Equal(t, "[DEBUG] test log: who=programmer\n", rest)
+		assertEqual(t, "[DEBUG] test log: who=programmer\n", rest)
 
 	})
 
@@ -65,14 +62,14 @@ func TestInterceptLogger(t *testing.T) {
 		dataIdx := strings.IndexByte(output, ' ')
 		rest := output[dataIdx+1:]
 
-		assert.Equal(t, "[INFO]  with_test: test1: a=1 b=2 c=3\n", rest)
+		assertEqual(t, "[INFO]  with_test: test1: a=1 b=2 c=3\n", rest)
 
 		// Ensure intercept works
 		output = sbuf.String()
 		dataIdx = strings.IndexByte(output, ' ')
 		rest = output[dataIdx+1:]
 
-		assert.Equal(t, "[INFO]  with_test: test1: a=1 b=2 c=3\n", rest)
+		assertEqual(t, "[INFO]  with_test: test1: a=1 b=2 c=3\n", rest)
 	})
 
 	t.Run("sink includes name", func(t *testing.T) {
@@ -99,14 +96,14 @@ func TestInterceptLogger(t *testing.T) {
 		dataIdx := strings.IndexByte(output, ' ')
 		rest := output[dataIdx+1:]
 
-		assert.Equal(t, "[INFO]  with_test.http: test1\n", rest)
+		assertEqual(t, "[INFO]  with_test.http: test1\n", rest)
 
 		// Ensure intercept works
 		output = sbuf.String()
 		dataIdx = strings.IndexByte(output, ' ')
 		rest = output[dataIdx+1:]
 
-		assert.Equal(t, "[INFO]  with_test.http: test1\n", rest)
+		assertEqual(t, "[INFO]  with_test.http: test1\n", rest)
 	})
 
 	t.Run("intercepting logger can create logger with reset name", func(t *testing.T) {
@@ -133,14 +130,14 @@ func TestInterceptLogger(t *testing.T) {
 		dataIdx := strings.IndexByte(output, ' ')
 		rest := output[dataIdx+1:]
 
-		assert.Equal(t, "[INFO]  http: test1\n", rest)
+		assertEqual(t, "[INFO]  http: test1\n", rest)
 
 		// Ensure intercept works
 		output = sbuf.String()
 		dataIdx = strings.IndexByte(output, ' ')
 		rest = output[dataIdx+1:]
 
-		assert.Equal(t, "[INFO]  http: test1\n", rest)
+		assertEqual(t, "[INFO]  http: test1\n", rest)
 	})
 
 	t.Run("Intercepting logger sink can deregister itself", func(t *testing.T) {
@@ -162,7 +159,7 @@ func TestInterceptLogger(t *testing.T) {
 
 		intercept.Info("test1")
 
-		assert.Equal(t, "", sbuf.String())
+		assertEqual(t, "", sbuf.String())
 	})
 
 	t.Run("Sinks accept different log formats", func(t *testing.T) {
@@ -187,14 +184,14 @@ func TestInterceptLogger(t *testing.T) {
 
 		intercept.Info("this is a test", "who", "caller")
 		_, file, line, ok := runtime.Caller(0)
-		require.True(t, ok)
+		requireTrue(t, ok)
 
 		output := buf.String()
 		dataIdx := strings.IndexByte(output, ' ')
 		rest := output[dataIdx+1:]
 
 		expected := fmt.Sprintf("[INFO]  go-hclog/interceptlogger_test.go:%d: this is a test: who=caller\n", line-1)
-		assert.Equal(t, expected, rest)
+		assertEqual(t, expected, rest)
 
 		b := sbuf.Bytes()
 
@@ -203,9 +200,9 @@ func TestInterceptLogger(t *testing.T) {
 			t.Fatal(err)
 		}
 
-		assert.Equal(t, "this is a test", raw["@message"])
-		assert.Equal(t, "caller", raw["who"])
-		assert.Equal(t, fmt.Sprintf("%v:%d", file, line-1), raw["@caller"])
+		assertEqual(t, "this is a test", raw["@message"].(string))
+		assertEqual(t, "caller", raw["who"].(string))
+		assertEqual(t, fmt.Sprintf("%v:%d", file, line-1), raw["@caller"].(string))
 	})
 
 	t.Run("handles parent with arguments and log level args", func(t *testing.T) {
@@ -234,7 +231,7 @@ func TestInterceptLogger(t *testing.T) {
 		output := buf.String()
 		dataIdx := strings.IndexByte(output, ' ')
 		rest := output[dataIdx+1:]
-		assert.Equal(t, "[DEBUG] with_test.sub_logger.http: test1: parent=logger path=/some/test/path args=[\"test\", \"test\"]\n", rest)
+		assertEqual(t, "[DEBUG] with_test.sub_logger.http: test1: parent=logger path=/some/test/path args=[\"test\", \"test\"]\n", rest)
 	})
 
 	t.Run("derived standard loggers send output to sinks", func(t *testing.T) {
@@ -261,12 +258,12 @@ func TestInterceptLogger(t *testing.T) {
 		output := buf.String()
 		dataIdx := strings.IndexByte(output, ' ')
 		rest := output[dataIdx+1:]
-		assert.Equal(t, "[DEBUG] with_name: test log\n", rest)
+		assertEqual(t, "[DEBUG] with_name: test log\n", rest)
 
 		output = sbuf.String()
 		dataIdx = strings.IndexByte(output, ' ')
 		rest = output[dataIdx+1:]
-		assert.Equal(t, "[DEBUG] with_name: test log\n", rest)
+		assertEqual(t, "[DEBUG] with_name: test log\n", rest)
 	})
 
 	t.Run("includes the caller location", func(t *testing.T) {
@@ -289,19 +286,19 @@ func TestInterceptLogger(t *testing.T) {
 
 		logger.Info("this is test", "who", "programmer", "why", "testing is fun")
 		_, _, line, ok := runtime.Caller(0)
-		require.True(t, ok)
+		requireTrue(t, ok)
 
 		str := buf.String()
 		dataIdx := strings.IndexByte(str, ' ')
 		rest := str[dataIdx+1:]
 
 		expected := fmt.Sprintf("[INFO]  go-hclog/interceptlogger_test.go:%d: test: this is test: who=programmer why=\"testing is fun\"\n", line-1)
-		assert.Equal(t, expected, rest)
+		assertEqual(t, expected, rest)
 
 		str = sbuf.String()
 		dataIdx = strings.IndexByte(str, ' ')
 		rest = str[dataIdx+1:]
-		assert.Equal(t, expected, rest)
+		assertEqual(t, expected, rest)
 	})
 
 	t.Run("supports resetting the output", func(t *testing.T) {
@@ -317,7 +314,7 @@ func TestInterceptLogger(t *testing.T) {
 		dataIdx := strings.IndexByte(str, ' ')
 		rest := str[dataIdx+1:]
 
-		assert.Equal(t, "[INFO]  this is test: production=\"12 beans/day\"\n", rest)
+		assertEqual(t, "[INFO]  this is test: production=\"12 beans/day\"\n", rest)
 
 		logger.(OutputResettable).ResetOutput(&LoggerOptions{
 			Output: &second,
@@ -328,12 +325,12 @@ func TestInterceptLogger(t *testing.T) {
 		str = first.String()
 		dataIdx = strings.IndexByte(str, ' ')
 		rest = str[dataIdx+1:]
-		assert.Equal(t, "[INFO]  this is test: production=\"12 beans/day\"\n", rest)
+		assertEqual(t, "[INFO]  this is test: production=\"12 beans/day\"\n", rest)
 
 		str = second.String()
 		dataIdx = strings.IndexByte(str, ' ')
 		rest = str[dataIdx+1:]
-		assert.Equal(t, "[INFO]  this is another test: production=\"13 beans/day\"\n", rest)
+		assertEqual(t, "[INFO]  this is another test: production=\"13 beans/day\"\n", rest)
 	})
 
 	t.Run("supports resetting the output with flushing", func(t *testing.T) {
@@ -347,7 +344,7 @@ func TestInterceptLogger(t *testing.T) {
 		logger.Info("this is test", "production", Fmt("%d beans/day", 12))
 
 		str := first.String()
-		assert.Empty(t, str)
+		assertEmpty(t, str)
 
 		logger.(OutputResettable).ResetOutputWithFlush(&LoggerOptions{
 			Output: &second,
@@ -358,11 +355,11 @@ func TestInterceptLogger(t *testing.T) {
 		str = first.String()
 		dataIdx := strings.IndexByte(str, ' ')
 		rest := str[dataIdx+1:]
-		assert.Equal(t, "[INFO]  this is test: production=\"12 beans/day\"\n", rest)
+		assertEqual(t, "[INFO]  this is test: production=\"12 beans/day\"\n", rest)
 
 		str = second.String()
 		dataIdx = strings.IndexByte(str, ' ')
 		rest = str[dataIdx+1:]
-		assert.Equal(t, "[INFO]  this is another test: production=\"13 beans/day\"\n", rest)
+		assertEqual(t, "[INFO]  this is another test: production=\"13 beans/day\"\n", rest)
 	})
 }

--- a/logger_loc_test.go
+++ b/logger_loc_test.go
@@ -4,8 +4,6 @@ import (
 	"bytes"
 	"strings"
 	"testing"
-
-	"github.com/stretchr/testify/assert"
 )
 
 // This file contains tests that are sensitive to their location in the file,
@@ -29,7 +27,7 @@ func TestLoggerLoc(t *testing.T) {
 		rest := str[dataIdx+1:]
 
 		// This test will break if you move this around, it's line dependent, just fyi
-		assert.Equal(t, "[INFO]  go-hclog/logger_loc_test.go:25: test: this is test: who=programmer why=\"testing is fun\"\n", rest)
+		assertEqual(t, "[INFO]  go-hclog/logger_loc_test.go:23: test: this is test: who=programmer why=\"testing is fun\"\n", rest)
 	})
 
 	t.Run("includes the caller location excluding helper functions", func(t *testing.T) {
@@ -53,7 +51,7 @@ func TestLoggerLoc(t *testing.T) {
 		rest := str[dataIdx+1:]
 
 		// This test will break if you move this around, it's line dependent, just fyi
-		assert.Equal(t, "[INFO]  go-hclog/logger_loc_test.go:49: test: this is test: who=programmer why=\"testing is fun\"\n", rest)
+		assertEqual(t, "[INFO]  go-hclog/logger_loc_test.go:47: test: this is test: who=programmer why=\"testing is fun\"\n", rest)
 	})
 
 }

--- a/logger_test.go
+++ b/logger_test.go
@@ -11,9 +11,6 @@ import (
 	"strings"
 	"testing"
 	"time"
-
-	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
 )
 
 type bufferingBuffer struct {
@@ -49,7 +46,7 @@ func TestLogger(t *testing.T) {
 		dataIdx := strings.IndexByte(str, ' ')
 		rest := str[dataIdx+1:]
 
-		assert.Equal(t, "[INFO]  test: this is test: who=programmer why=testing\n", rest)
+		assertEqual(t, "[INFO]  test: this is test: who=programmer why=testing\n", rest)
 	})
 
 	t.Run("formats log entries", func(t *testing.T) {
@@ -66,7 +63,7 @@ func TestLogger(t *testing.T) {
 		dataIdx := strings.IndexByte(str, ' ')
 		rest := str[dataIdx+1:]
 
-		assert.Equal(t, "[INFO]  test: this is test: who=programmer why=testing\n", rest)
+		assertEqual(t, "[INFO]  test: this is test: who=programmer why=testing\n", rest)
 	})
 
 	t.Run("renders slice values specially", func(t *testing.T) {
@@ -83,7 +80,7 @@ func TestLogger(t *testing.T) {
 		dataIdx := strings.IndexByte(str, ' ')
 		rest := str[dataIdx+1:]
 
-		assert.Equal(t, "[INFO]  test: this is test: who=programmer why=[testing, dev, 1, 5, \"[3 4]\"]\n", rest)
+		assertEqual(t, "[INFO]  test: this is test: who=programmer why=[testing, dev, 1, 5, \"[3 4]\"]\n", rest)
 	})
 
 	t.Run("renders values in slices with quotes", func(t *testing.T) {
@@ -100,7 +97,7 @@ func TestLogger(t *testing.T) {
 		dataIdx := strings.IndexByte(str, ' ')
 		rest := str[dataIdx+1:]
 
-		assert.Equal(t, "[INFO]  test: this is test: who=programmer why=[\"testing & qa\", \"dev\"]\n", rest)
+		assertEqual(t, "[INFO]  test: this is test: who=programmer why=[\"testing & qa\", \"dev\"]\n", rest)
 	})
 
 	t.Run("escapes quotes in values", func(t *testing.T) {
@@ -117,7 +114,7 @@ func TestLogger(t *testing.T) {
 		dataIdx := strings.IndexByte(str, ' ')
 		rest := str[dataIdx+1:]
 
-		assert.Equal(t, `[INFO]  test: this is test: who=programmer why="this is \"quoted\""`+"\n", rest)
+		assertEqual(t, `[INFO]  test: this is test: who=programmer why="this is \"quoted\""`+"\n", rest)
 	})
 
 	t.Run("prints empty double quotes for empty strings", func(t *testing.T) {
@@ -134,7 +131,7 @@ func TestLogger(t *testing.T) {
 		dataIdx := strings.IndexByte(str, ' ')
 		rest := str[dataIdx+1:]
 
-		assert.Equal(t, `[INFO]  test: this is test: who=programmer why=""`+"\n", rest)
+		assertEqual(t, `[INFO]  test: this is test: who=programmer why=""`+"\n", rest)
 	})
 
 	t.Run("quotes when there are nonprintable sequences in a value", func(t *testing.T) {
@@ -151,7 +148,7 @@ func TestLogger(t *testing.T) {
 		dataIdx := strings.IndexByte(str, ' ')
 		rest := str[dataIdx+1:]
 
-		assert.Equal(t, "[INFO]  test: this is test: who=programmer why=\"\U0001F603\"\n", rest)
+		assertEqual(t, "[INFO]  test: this is test: who=programmer why=\"\U0001F603\"\n", rest)
 	})
 
 	t.Run("formats multiline values nicely", func(t *testing.T) {
@@ -173,7 +170,7 @@ func TestLogger(t *testing.T) {
   | testing
   | and other
   | pretty cool things` + "\n  \n"
-		assert.Equal(t, expected, rest)
+		assertEqual(t, expected, rest)
 	})
 
 	t.Run("outputs stack traces", func(t *testing.T) {
@@ -187,9 +184,9 @@ func TestLogger(t *testing.T) {
 		logger.Info("who", "programmer", "why", "testing", Stacktrace())
 
 		lines := strings.Split(buf.String(), "\n")
-		require.True(t, len(lines) > 1)
+		requireTrue(t, len(lines) > 1)
 
-		assert.Equal(t, "github.com/hashicorp/go-hclog.Stacktrace", lines[1])
+		assertEqual(t, "github.com/hashicorp/go-hclog.Stacktrace", lines[1])
 	})
 
 	t.Run("outputs stack traces with it's given a name", func(t *testing.T) {
@@ -203,9 +200,9 @@ func TestLogger(t *testing.T) {
 		logger.Info("who", "programmer", "why", "testing", "foo", Stacktrace())
 
 		lines := strings.Split(buf.String(), "\n")
-		require.True(t, len(lines) > 1)
+		requireTrue(t, len(lines) > 1)
 
-		assert.Equal(t, "github.com/hashicorp/go-hclog.Stacktrace", lines[1])
+		assertEqual(t, "github.com/hashicorp/go-hclog.Stacktrace", lines[1])
 	})
 
 	t.Run("prefixes the name", func(t *testing.T) {
@@ -220,7 +217,7 @@ func TestLogger(t *testing.T) {
 		str := buf.String()
 		dataIdx := strings.IndexByte(str, ' ')
 		rest := str[dataIdx+1:]
-		assert.Equal(t, "[INFO]  this is test\n", rest)
+		assertEqual(t, "[INFO]  this is test\n", rest)
 
 		buf.Reset()
 
@@ -229,7 +226,7 @@ func TestLogger(t *testing.T) {
 		str = buf.String()
 		dataIdx = strings.IndexByte(str, ' ')
 		rest = str[dataIdx+1:]
-		assert.Equal(t, "[INFO]  sublogger: this is test\n", rest)
+		assertEqual(t, "[INFO]  sublogger: this is test\n", rest)
 	})
 
 	t.Run("use a different time format", func(t *testing.T) {
@@ -246,7 +243,7 @@ func TestLogger(t *testing.T) {
 		str := buf.String()
 		dataIdx := strings.IndexByte(str, ' ')
 
-		assert.Equal(t, str[:dataIdx], time.Now().Format(time.Kitchen))
+		assertEqual(t, str[:dataIdx], time.Now().Format(time.Kitchen))
 	})
 
 	t.Run("use UTC time zone", func(t *testing.T) {
@@ -264,7 +261,7 @@ func TestLogger(t *testing.T) {
 		str := buf.String()
 		dataIdx := strings.IndexByte(str, ' ')
 
-		assert.Equal(t, str[:dataIdx], time.Now().UTC().Format(time.Kitchen))
+		assertEqual(t, str[:dataIdx], time.Now().UTC().Format(time.Kitchen))
 	})
 
 	t.Run("respects DisableTime", func(t *testing.T) {
@@ -280,7 +277,7 @@ func TestLogger(t *testing.T) {
 
 		str := buf.String()
 
-		assert.Equal(t, "[INFO]  test: Señorita banana\n", str)
+		assertEqual(t, "[INFO]  test: Señorita banana\n", str)
 	})
 
 	t.Run("use with", func(t *testing.T) {
@@ -303,14 +300,14 @@ func TestLogger(t *testing.T) {
 		derived1.Info("test1")
 		output := buf.String()
 		dataIdx := strings.IndexByte(output, ' ')
-		assert.Equal(t, "[INFO]  with_test: test1: a=1 b=2 c=3 cat=30\n", output[dataIdx+1:])
+		assertEqual(t, "[INFO]  with_test: test1: a=1 b=2 c=3 cat=30\n", output[dataIdx+1:])
 
 		buf.Reset()
 
 		derived2.Info("test2")
 		output = buf.String()
 		dataIdx = strings.IndexByte(output, ' ')
-		assert.Equal(t, "[INFO]  with_test: test2: a=1 b=2 c=3 dog=40\n", output[dataIdx+1:])
+		assertEqual(t, "[INFO]  with_test: test2: a=1 b=2 c=3 dog=40\n", output[dataIdx+1:])
 	})
 
 	t.Run("unpaired with", func(t *testing.T) {
@@ -325,7 +322,7 @@ func TestLogger(t *testing.T) {
 		derived1.Info("test1")
 		output := buf.String()
 		dataIdx := strings.IndexByte(output, ' ')
-		assert.Equal(t, "[INFO]  with_test: test1: EXTRA_VALUE_AT_END=a\n", output[dataIdx+1:])
+		assertEqual(t, "[INFO]  with_test: test1: EXTRA_VALUE_AT_END=a\n", output[dataIdx+1:])
 	})
 
 	t.Run("use with and log", func(t *testing.T) {
@@ -350,14 +347,14 @@ func TestLogger(t *testing.T) {
 		rootLogger.Info("root_test", "bird", 10)
 		output := buf.String()
 		dataIdx := strings.IndexByte(output, ' ')
-		assert.Equal(t, "[INFO]  with_test: root_test: a=1 b=2 c=3 bird=10\n", output[dataIdx+1:])
+		assertEqual(t, "[INFO]  with_test: root_test: a=1 b=2 c=3 bird=10\n", output[dataIdx+1:])
 
 		buf.Reset()
 
 		derived.Info("derived_test")
 		output = buf.String()
 		dataIdx = strings.IndexByte(output, ' ')
-		assert.Equal(t, "[INFO]  with_test: derived_test: a=1 b=2 c=3 cat=30\n", output[dataIdx+1:])
+		assertEqual(t, "[INFO]  with_test: derived_test: a=1 b=2 c=3 cat=30\n", output[dataIdx+1:])
 	})
 
 	t.Run("use with and log and change levels", func(t *testing.T) {
@@ -396,14 +393,14 @@ func TestLogger(t *testing.T) {
 		rootLogger.Info("root_test", "bird", 10)
 		output = buf.String()
 		dataIdx := strings.IndexByte(output, ' ')
-		assert.Equal(t, "[INFO]  with_test: root_test: a=1 b=2 c=3 bird=10\n", output[dataIdx+1:])
+		assertEqual(t, "[INFO]  with_test: root_test: a=1 b=2 c=3 bird=10\n", output[dataIdx+1:])
 
 		buf.Reset()
 
 		derived.Info("derived_test")
 		output = buf.String()
 		dataIdx = strings.IndexByte(output, ' ')
-		assert.Equal(t, "[INFO]  with_test: derived_test: a=1 b=2 c=3 cat=30\n", output[dataIdx+1:])
+		assertEqual(t, "[INFO]  with_test: derived_test: a=1 b=2 c=3 cat=30\n", output[dataIdx+1:])
 	})
 
 	t.Run("supports Printf style expansions when requested", func(t *testing.T) {
@@ -420,7 +417,7 @@ func TestLogger(t *testing.T) {
 		dataIdx := strings.IndexByte(str, ' ')
 		rest := str[dataIdx+1:]
 
-		assert.Equal(t, "[INFO]  test: this is test: production=\"12 beans/day\"\n", rest)
+		assertEqual(t, "[INFO]  test: this is test: production=\"12 beans/day\"\n", rest)
 	})
 
 	t.Run("supports number formating", func(t *testing.T) {
@@ -437,7 +434,7 @@ func TestLogger(t *testing.T) {
 		dataIdx := strings.IndexByte(str, ' ')
 		rest := str[dataIdx+1:]
 
-		assert.Equal(t, "[INFO]  test: this is test: bytes=0xc perms=0755 bits=0b101\n", rest)
+		assertEqual(t, "[INFO]  test: this is test: bytes=0xc perms=0755 bits=0b101\n", rest)
 	})
 
 	t.Run("supports quote formatting", func(t *testing.T) {
@@ -461,7 +458,7 @@ func TestLogger(t *testing.T) {
 		dataIdx := strings.IndexByte(str, ' ')
 		rest := str[dataIdx+1:]
 
-		assert.Equal(t, "[INFO]  test: this is test: "+
+		assertEqual(t, "[INFO]  test: this is test: "+
 			"unquoted=unquoted quoted=\"quoted\" "+
 			"unsafeq=\"foo\\nbar\\bbaz\\xffa\"\n", rest)
 	})
@@ -479,7 +476,7 @@ func TestLogger(t *testing.T) {
 		dataIdx := strings.IndexByte(str, ' ')
 		rest := str[dataIdx+1:]
 
-		assert.Equal(t, "[INFO]  this is test: production=\"12 beans/day\"\n", rest)
+		assertEqual(t, "[INFO]  this is test: production=\"12 beans/day\"\n", rest)
 
 		logger.(OutputResettable).ResetOutput(&LoggerOptions{
 			Output: &second,
@@ -490,12 +487,12 @@ func TestLogger(t *testing.T) {
 		str = first.String()
 		dataIdx = strings.IndexByte(str, ' ')
 		rest = str[dataIdx+1:]
-		assert.Equal(t, "[INFO]  this is test: production=\"12 beans/day\"\n", rest)
+		assertEqual(t, "[INFO]  this is test: production=\"12 beans/day\"\n", rest)
 
 		str = second.String()
 		dataIdx = strings.IndexByte(str, ' ')
 		rest = str[dataIdx+1:]
-		assert.Equal(t, "[INFO]  this is another test: production=\"13 beans/day\"\n", rest)
+		assertEqual(t, "[INFO]  this is another test: production=\"13 beans/day\"\n", rest)
 	})
 
 	t.Run("supports resetting the output with flushing", func(t *testing.T) {
@@ -509,7 +506,7 @@ func TestLogger(t *testing.T) {
 		logger.Info("this is test", "production", Fmt("%d beans/day", 12))
 
 		str := first.String()
-		assert.Empty(t, str)
+		assertEmpty(t, str)
 
 		logger.(OutputResettable).ResetOutputWithFlush(&LoggerOptions{
 			Output: &second,
@@ -520,12 +517,12 @@ func TestLogger(t *testing.T) {
 		str = first.String()
 		dataIdx := strings.IndexByte(str, ' ')
 		rest := str[dataIdx+1:]
-		assert.Equal(t, "[INFO]  this is test: production=\"12 beans/day\"\n", rest)
+		assertEqual(t, "[INFO]  this is test: production=\"12 beans/day\"\n", rest)
 
 		str = second.String()
 		dataIdx = strings.IndexByte(str, ' ')
 		rest = str[dataIdx+1:]
-		assert.Equal(t, "[INFO]  this is another test: production=\"13 beans/day\"\n", rest)
+		assertEqual(t, "[INFO]  this is another test: production=\"13 beans/day\"\n", rest)
 	})
 
 	t.Run("named logger with disabled parent", func(t *testing.T) {
@@ -552,7 +549,7 @@ func TestLogger(t *testing.T) {
 		str = buf.String()
 		dataIdx := strings.IndexByte(str, ' ')
 		rest := str[dataIdx+1:]
-		assert.Equal(t, "[INFO]  sublogger: this is test\n", rest)
+		assertEqual(t, "[INFO]  sublogger: this is test\n", rest)
 
 		buf.Reset()
 		logger.Info("parent should still be quiet")
@@ -579,7 +576,7 @@ func TestLogger_leveledWriter(t *testing.T) {
 		errDataIdx := strings.IndexByte(errStr, ' ')
 		errRest := errStr[errDataIdx+1:]
 
-		assert.Equal(t, "[ERROR] test: this is an error: who=programmer why=testing\n", errRest)
+		assertEqual(t, "[ERROR] test: this is an error: who=programmer why=testing\n", errRest)
 	})
 
 	t.Run("writes non-errors to stdout", func(t *testing.T) {
@@ -597,7 +594,7 @@ func TestLogger_leveledWriter(t *testing.T) {
 		outDataIdx := strings.IndexByte(outStr, ' ')
 		outRest := outStr[outDataIdx+1:]
 
-		assert.Equal(t, "[INFO]  test: this is test: who=programmer why=testing\n", outRest)
+		assertEqual(t, "[INFO]  test: this is test: who=programmer why=testing\n", outRest)
 	})
 
 	t.Run("writes errors and non-errors correctly", func(t *testing.T) {
@@ -620,8 +617,8 @@ func TestLogger_leveledWriter(t *testing.T) {
 		outDataIdx := strings.IndexByte(outStr, ' ')
 		outRest := outStr[outDataIdx+1:]
 
-		assert.Equal(t, "[ERROR] test: this is an error: who=programmer why=testing\n", errRest)
-		assert.Equal(t, "[INFO]  test: this is test: who=programmer why=testing\n", outRest)
+		assertEqual(t, "[ERROR] test: this is an error: who=programmer why=testing\n", errRest)
+		assertEqual(t, "[INFO]  test: this is test: who=programmer why=testing\n", outRest)
 	})
 }
 
@@ -643,9 +640,9 @@ func TestLogger_JSON(t *testing.T) {
 			t.Fatal(err)
 		}
 
-		assert.Equal(t, "this is test", raw["@message"])
-		assert.Equal(t, "programmer", raw["who"])
-		assert.Equal(t, "testing is fun", raw["why"])
+		assertEqual(t, "this is test", raw["@message"].(string))
+		assertEqual(t, "programmer", raw["who"].(string))
+		assertEqual(t, "testing is fun", raw["why"].(string))
 	})
 
 	t.Run("use a different time format", func(t *testing.T) {
@@ -672,7 +669,7 @@ func TestLogger_JSON(t *testing.T) {
 			t.Fatal("missing '@timestamp' key")
 		}
 
-		assert.Equal(t, val, time.Now().Format(time.Kitchen))
+		assertEqual(t, val.(string), time.Now().Format(time.Kitchen))
 	})
 
 	t.Run("use UTC time zone", func(t *testing.T) {
@@ -700,7 +697,7 @@ func TestLogger_JSON(t *testing.T) {
 			t.Fatal("missing '@timestamp' key")
 		}
 
-		assert.Equal(t, val, time.Now().UTC().Format(time.Kitchen))
+		assertEqual(t, val.(string), time.Now().UTC().Format(time.Kitchen))
 	})
 
 	t.Run("respects DisableTime", func(t *testing.T) {
@@ -744,11 +741,11 @@ func TestLogger_JSON(t *testing.T) {
 			t.Fatal(err)
 		}
 
-		assert.Equal(t, "this is test", raw["@message"])
-		assert.Equal(t, "programmer", raw["who"])
-		assert.Equal(t, "testing is fun", raw["why"])
-		assert.Equal(t, "in the hat", raw["cat"])
-		assert.Equal(t, float64(42), raw["dog"])
+		assertEqual(t, "this is test", raw["@message"].(string))
+		assertEqual(t, "programmer", raw["who"].(string))
+		assertEqual(t, "testing is fun", raw["why"].(string))
+		assertEqual(t, "in the hat", raw["cat"].(string))
+		assertEqual(t, fmt.Sprintf("%g", float64(42)), fmt.Sprintf("%g", raw["dog"].(float64)))
 	})
 
 	t.Run("json formatting error type", func(t *testing.T) {
@@ -770,9 +767,9 @@ func TestLogger_JSON(t *testing.T) {
 			t.Fatal(err)
 		}
 
-		assert.Equal(t, "this is test", raw["@message"])
-		assert.Equal(t, "programmer", raw["who"])
-		assert.Equal(t, errMsg.Error(), raw["err"])
+		assertEqual(t, "this is test", raw["@message"].(string))
+		assertEqual(t, "programmer", raw["who"].(string))
+		assertEqual(t, errMsg.Error(), raw["err"].(string))
 	})
 
 	t.Run("json formatting custom error type json marshaler", func(t *testing.T) {
@@ -803,9 +800,9 @@ func TestLogger_JSON(t *testing.T) {
 			t.Fatal(err)
 		}
 
-		assert.Equal(t, "this is test", raw["@message"])
-		assert.Equal(t, "programmer", raw["who"])
-		assert.Equal(t, expectedMsg, raw["err"])
+		assertEqual(t, "this is test", raw["@message"].(string))
+		assertEqual(t, "programmer", raw["who"].(string))
+		assertEqual(t, expectedMsg, raw["err"].(string))
 	})
 
 	t.Run("json formatting custom error type text marshaler", func(t *testing.T) {
@@ -833,9 +830,9 @@ func TestLogger_JSON(t *testing.T) {
 			t.Fatal(err)
 		}
 
-		assert.Equal(t, "this is test", raw["@message"])
-		assert.Equal(t, "programmer", raw["who"])
-		assert.Equal(t, expectedMsg, raw["err"])
+		assertEqual(t, "this is test", raw["@message"].(string))
+		assertEqual(t, "programmer", raw["who"].(string))
+		assertEqual(t, expectedMsg, raw["err"].(string))
 	})
 
 	t.Run("supports Printf style expansions when requested", func(t *testing.T) {
@@ -856,8 +853,8 @@ func TestLogger_JSON(t *testing.T) {
 			t.Fatal(err)
 		}
 
-		assert.Equal(t, "this is test", raw["@message"])
-		assert.Equal(t, "12 beans/day", raw["production"])
+		assertEqual(t, "this is test", raw["@message"].(string))
+		assertEqual(t, "12 beans/day", raw["production"].(string))
 	})
 
 	t.Run("ignores number formatting requests", func(t *testing.T) {
@@ -878,10 +875,10 @@ func TestLogger_JSON(t *testing.T) {
 			t.Fatal(err)
 		}
 
-		assert.Equal(t, "this is test", raw["@message"])
-		assert.Equal(t, float64(12), raw["bytes"])
-		assert.Equal(t, float64(0755), raw["perms"])
-		assert.Equal(t, float64(5), raw["bits"])
+		assertEqual(t, "this is test", raw["@message"].(string))
+		assertEqual(t, fmt.Sprintf("%g", float64(12)), fmt.Sprintf("%g", raw["bytes"].(float64)))
+		assertEqual(t, fmt.Sprintf("%g", float64(0755)), fmt.Sprintf("%g", raw["perms"].(float64)))
+		assertEqual(t, fmt.Sprintf("%g", float64(5)), fmt.Sprintf("%g", raw["bits"].(float64)))
 	})
 
 	t.Run("ignores quote formatting requests", func(t *testing.T) {
@@ -907,7 +904,7 @@ func TestLogger_JSON(t *testing.T) {
 		// Assert the JSON only contains valid utf8 strings with the
 		// illegal byte replaced with the utf8 replacement character,
 		// and not invalid json with byte(255)
-		// Note: testify/assert.Contains did not work here
+		// Note: testify/assertContains did not work here
 		if needle := []byte(`\ufffda`); !bytes.Contains(b, needle) {
 			t.Fatalf("could not find %q (%v) in json bytes: %q", needle, needle, b)
 		}
@@ -920,11 +917,11 @@ func TestLogger_JSON(t *testing.T) {
 			t.Fatal(err)
 		}
 
-		assert.Equal(t, "this is test", raw["@message"])
-		assert.Equal(t, "unquoted", raw["unquoted"])
-		assert.Equal(t, "quoted", raw["quoted"])
-		assert.Equal(t, "foo\nbar\bbaz\uFFFDa", raw["unsafe"])
-		assert.Equal(t, "foo\nbar\bbaz\uFFFDa", raw["unsafeq"])
+		assertEqual(t, "this is test", raw["@message"].(string))
+		assertEqual(t, "unquoted", raw["unquoted"].(string))
+		assertEqual(t, "quoted", raw["quoted"].(string))
+		assertEqual(t, "foo\nbar\bbaz\uFFFDa", raw["unsafe"].(string))
+		assertEqual(t, "foo\nbar\bbaz\uFFFDa", raw["unsafeq"].(string))
 	})
 
 	t.Run("includes the caller location", func(t *testing.T) {
@@ -939,7 +936,7 @@ func TestLogger_JSON(t *testing.T) {
 
 		logger.Info("this is test")
 		_, file, line, ok := runtime.Caller(0)
-		require.True(t, ok)
+		requireTrue(t, ok)
 
 		b := buf.Bytes()
 
@@ -948,8 +945,8 @@ func TestLogger_JSON(t *testing.T) {
 			t.Fatal(err)
 		}
 
-		assert.Equal(t, "this is test", raw["@message"])
-		assert.Equal(t, fmt.Sprintf("%v:%d", file, line-1), raw["@caller"])
+		assertEqual(t, "this is test", raw["@message"].(string))
+		assertEqual(t, fmt.Sprintf("%v:%d", file, line-1), raw["@caller"].(string))
 	})
 
 	t.Run("includes the caller location excluding helper functions", func(t *testing.T) {
@@ -969,7 +966,7 @@ func TestLogger_JSON(t *testing.T) {
 
 		logMe(logger)
 		_, file, line, ok := runtime.Caller(0)
-		require.True(t, ok)
+		requireTrue(t, ok)
 
 		b := buf.Bytes()
 
@@ -978,8 +975,8 @@ func TestLogger_JSON(t *testing.T) {
 			t.Fatal(err)
 		}
 
-		assert.Equal(t, "this is test", raw["@message"])
-		assert.Equal(t, fmt.Sprintf("%v:%d", file, line-1), raw["@caller"])
+		assertEqual(t, "this is test", raw["@message"].(string))
+		assertEqual(t, fmt.Sprintf("%v:%d", file, line-1), raw["@caller"].(string))
 	})
 
 	t.Run("handles non-serializable entries", func(t *testing.T) {
@@ -1001,8 +998,8 @@ func TestLogger_JSON(t *testing.T) {
 			t.Fatal(err)
 		}
 
-		assert.Equal(t, "this is test", raw["@message"])
-		assert.Equal(t, errJsonUnsupportedTypeMsg, raw["@warn"])
+		assertEqual(t, "this is test", raw["@message"].(string))
+		assertEqual(t, errJsonUnsupportedTypeMsg, raw["@warn"].(string))
 	})
 }
 

--- a/nulllogger_test.go
+++ b/nulllogger_test.go
@@ -2,8 +2,6 @@ package hclog
 
 import (
 	"testing"
-
-	"github.com/stretchr/testify/assert"
 )
 
 var logger = NewNullLogger()
@@ -12,11 +10,11 @@ func TestNullLoggerIsEfficient(t *testing.T) {
 	// Since statements like "IsWarn()", "IsError()", etc. are used to gate
 	// actually writing warning and error statements, the null logger will
 	// be faster and more efficient if it always returns false for these calls.
-	assert.False(t, logger.IsTrace())
-	assert.False(t, logger.IsDebug())
-	assert.False(t, logger.IsInfo())
-	assert.False(t, logger.IsWarn())
-	assert.False(t, logger.IsError())
+	assertFalse(t, logger.IsTrace())
+	assertFalse(t, logger.IsDebug())
+	assertFalse(t, logger.IsInfo())
+	assertFalse(t, logger.IsWarn())
+	assertFalse(t, logger.IsError())
 }
 
 func TestNullLoggerReturnsNullLoggers(t *testing.T) {
@@ -26,20 +24,22 @@ func TestNullLoggerReturnsNullLoggers(t *testing.T) {
 
 	subLogger := logger.With()
 	_, ok := subLogger.(*nullLogger)
-	assert.True(t, ok)
+	assertTrue(t, ok)
 
 	subLogger = logger.Named("")
 	_, ok = subLogger.(*nullLogger)
-	assert.True(t, ok)
+	assertTrue(t, ok)
 
 	subLogger = logger.ResetNamed("")
 	_, ok = subLogger.(*nullLogger)
-	assert.True(t, ok)
+	assertTrue(t, ok)
 }
 
 func TestStandardLoggerIsntNil(t *testing.T) {
 	// Don't return a nil pointer for the standard logger,
 	// lest it cause a panic.
 	stdLogger := logger.StandardLogger(nil)
-	assert.NotEqual(t, nil, stdLogger)
+	if stdLogger == nil {
+		t.Fatalf("expected non-nil")
+	}
 }

--- a/stdlog_test.go
+++ b/stdlog_test.go
@@ -8,9 +8,6 @@ import (
 	"runtime"
 	"strings"
 	"testing"
-
-	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
 )
 
 func TestStdlogAdapter_PickLevel(t *testing.T) {
@@ -19,8 +16,8 @@ func TestStdlogAdapter_PickLevel(t *testing.T) {
 
 		level, rest := s.pickLevel("[DEBUG] coffee?")
 
-		assert.Equal(t, Debug, level)
-		assert.Equal(t, "coffee?", rest)
+		assertEqual(t, Debug.String(), level.String())
+		assertEqual(t, "coffee?", rest)
 	})
 
 	t.Run("picks trace level", func(t *testing.T) {
@@ -28,8 +25,8 @@ func TestStdlogAdapter_PickLevel(t *testing.T) {
 
 		level, rest := s.pickLevel("[TRACE] coffee?")
 
-		assert.Equal(t, Trace, level)
-		assert.Equal(t, "coffee?", rest)
+		assertEqual(t, Trace.String(), level.String())
+		assertEqual(t, "coffee?", rest)
 	})
 
 	t.Run("picks info level", func(t *testing.T) {
@@ -37,8 +34,8 @@ func TestStdlogAdapter_PickLevel(t *testing.T) {
 
 		level, rest := s.pickLevel("[INFO] coffee?")
 
-		assert.Equal(t, Info, level)
-		assert.Equal(t, "coffee?", rest)
+		assertEqual(t, Info.String(), level.String())
+		assertEqual(t, "coffee?", rest)
 	})
 
 	t.Run("picks warn level", func(t *testing.T) {
@@ -46,8 +43,8 @@ func TestStdlogAdapter_PickLevel(t *testing.T) {
 
 		level, rest := s.pickLevel("[WARN] coffee?")
 
-		assert.Equal(t, Warn, level)
-		assert.Equal(t, "coffee?", rest)
+		assertEqual(t, Warn.String(), level.String())
+		assertEqual(t, "coffee?", rest)
 	})
 
 	t.Run("picks error level", func(t *testing.T) {
@@ -55,8 +52,8 @@ func TestStdlogAdapter_PickLevel(t *testing.T) {
 
 		level, rest := s.pickLevel("[ERROR] coffee?")
 
-		assert.Equal(t, Error, level)
-		assert.Equal(t, "coffee?", rest)
+		assertEqual(t, Error.String(), level.String())
+		assertEqual(t, "coffee?", rest)
 	})
 
 	t.Run("picks error as err level", func(t *testing.T) {
@@ -64,8 +61,8 @@ func TestStdlogAdapter_PickLevel(t *testing.T) {
 
 		level, rest := s.pickLevel("[ERR] coffee?")
 
-		assert.Equal(t, Error, level)
-		assert.Equal(t, "coffee?", rest)
+		assertEqual(t, Error.String(), level.String())
+		assertEqual(t, "coffee?", rest)
 	})
 }
 
@@ -126,7 +123,7 @@ func TestStdlogAdapter_TrimTimestamp(t *testing.T) {
 		t.Run(c.name, func(t *testing.T) {
 			var s stdlogAdapter
 			got := s.trimTimestamp(c.input)
-			assert.Equal(t, c.expect, got)
+			assertEqual(t, c.expect, got)
 		})
 	}
 }
@@ -209,13 +206,13 @@ func TestStdlogAdapter_ForceLevel(t *testing.T) {
 			}
 
 			_, err := s.Write([]byte(c.write))
-			assert.NoError(t, err)
+			assertNoError(t, err)
 
 			errStr := stderr.String()
 			errDataIdx := strings.IndexByte(errStr, ' ')
 			errRest := errStr[errDataIdx+1:]
 
-			assert.Equal(t, c.expect, errRest)
+			assertEqual(t, c.expect, errRest)
 		})
 	}
 }
@@ -232,16 +229,16 @@ func TestFromStandardLogger(t *testing.T) {
 
 	hl.Info("this is a test", "name", "tester", "count", 1)
 	_, file, line, ok := runtime.Caller(0)
-	require.True(t, ok)
+	requireTrue(t, ok)
 
 	actual := buf.String()
 	suffix := fmt.Sprintf(
 		"[INFO]  go-hclog/%s:%d: hclog-inner: this is a test: name=tester count=1\n",
 		filepath.Base(file), line-1)
-	require.Equal(t, suffix, actual[25:])
+	requireEqual(t, suffix, actual[25:])
 
 	prefix := "test-stdlib-log "
-	require.Equal(t, prefix, actual[:16])
+	requireEqual(t, prefix, actual[:16])
 }
 
 func TestFromStandardLogger_helper(t *testing.T) {
@@ -261,14 +258,14 @@ func TestFromStandardLogger_helper(t *testing.T) {
 
 	helper()
 	_, file, line, ok := runtime.Caller(0)
-	require.True(t, ok)
+	requireTrue(t, ok)
 
 	actual := buf.String()
 	suffix := fmt.Sprintf(
 		"[INFO]  go-hclog/%s:%d: hclog-inner: this is a test: name=tester count=1\n",
 		filepath.Base(file), line-1)
-	require.Equal(t, suffix, actual[25:])
+	requireEqual(t, suffix, actual[25:])
 
 	prefix := "test-stdlib-log "
-	require.Equal(t, prefix, actual[:16])
+	requireEqual(t, prefix, actual[:16])
 }


### PR DESCRIPTION
Given this Go module underpins many others, it should likely try to minimize dependencies where possible. This removes the testify dependency by converting the unit testing logic to local testing helpers. Happy to adjust this change or take another approach.

---

## Additional Context

Ultimately this is reference to https://github.com/advisories/GHSA-hp87-p4gw-j4gq, where `gopkg.in/yaml.v3` recently had a CVE filed against it. That Go module is a dependency of this one via testify, according to `go mod why -m gopkg.in/yaml.v3`:

```
github.com/hashicorp/go-hclog
github.com/hashicorp/go-hclog.test
github.com/stretchr/testify/assert
gopkg.in/yaml.v3
```

Indirectly referencing a YAML handling module seems less than ideal for a logging system, especially if it is only for some testing helpers.

## References

- https://github.com/advisories/GHSA-hp87-p4gw-j4gq
- https://github.com/stretchr/testify/pull/1190
- https://github.com/go-yaml/yaml/issues/666
