### PR TITLE
fix GH test workflow after master -> main switch

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -2,9 +2,9 @@ name: go-hclog
 
 on:
   push:
-    branches: [ master ]
+    branches: [ main ]
   pull_request:
-    branches: [ master ]
+    branches: [ main ]
 
 jobs:
   test:


### PR DESCRIPTION
Looks like this didn't get updated whenever the master -> main switch happened.