### PR TITLE
Add `ColorHeaderAndFields` logger option

### DIFF
--- a/intlogger.go
+++ b/intlogger.go
@@ -53,8 +53,9 @@ var (
 		Error: color.New(color.FgHiRed),
 	}
 
-	faintBoldColor = color.New(color.Faint, color.Bold)
-	faintColor     = color.New(color.Faint)
+	faintBoldColor       = color.New(color.Faint, color.Bold)
+	faintColor           = color.New(color.Faint)
+	faintMultiLinePrefix = faintColor.Sprint(multiLinePrefix)
 )
 
 // Make sure that intLogger is a Logger
@@ -407,7 +408,7 @@ func (l *intLogger) logPlain(t time.Time, name string, level Level, msg string, 
 				l.writer.WriteString(key)
 				if l.fieldColor != ColorOff {
 					l.writer.WriteString(faintColor.Sprint("=\n"))
-					writeIndent(l.writer, val, faintColor.Sprint(multiLinePrefix))
+					writeIndent(l.writer, val, faintMultiLinePrefix)
 				} else {
 					l.writer.WriteString("=\n")
 					writeIndent(l.writer, val, multiLinePrefix)

--- a/intlogger.go
+++ b/intlogger.go
@@ -263,11 +263,10 @@ func (l *intLogger) logPlain(t time.Time, name string, level Level, msg string, 
 
 	s, ok := _levelToBracket[level]
 	if ok {
-		switch {
-		case l.headerColor != ColorOff:
+		if l.headerColor != ColorOff {
 			color := _levelToColor[level]
 			color.Fprint(l.writer, s)
-		default:
+		} else {
 			l.writer.WriteString(s)
 		}
 	} else {
@@ -397,8 +396,7 @@ func (l *intLogger) logPlain(t time.Time, name string, level Level, msg string, 
 			// Values may also neeq quoting, if not all the runes
 			// in the value string are "normal", like if they
 			// contain ANSI escape sequences.
-			switch {
-			case strings.Contains(val, "\n"):
+			if strings.Contains(val, "\n") {
 				key = "\n  " + key
 
 				valStrBuilder := &strings.Builder{}
@@ -417,7 +415,7 @@ func (l *intLogger) logPlain(t time.Time, name string, level Level, msg string, 
 				valStrBuilder.WriteString("  ")
 
 				val = valStrBuilder.String()
-			case !raw && needsQuoting(val):
+			} else if !raw && needsQuoting(val) {
 				val = strconv.Quote(val)
 			}
 

--- a/intlogger.go
+++ b/intlogger.go
@@ -32,6 +32,10 @@ const TimeFormatJSON = "2006-01-02T15:04:05.000000Z07:00"
 // errJsonUnsupportedTypeMsg is included in log json entries, if an arg cannot be serialized to json
 const errJsonUnsupportedTypeMsg = "logging contained values that don't serialize to json"
 
+// multiLinePrefix is used for fields that contain multi-line values
+// when using non-JSON logging.
+const multiLinePrefix = "  | "
+
 var (
 	_levelToBracket = map[Level]string{
 		Debug: "[DEBUG]",
@@ -401,22 +405,31 @@ func (l *intLogger) logPlain(t time.Time, name string, level Level, msg string, 
 			if strings.Contains(val, "\n") {
 				l.writer.WriteString("\n  ")
 				l.writer.WriteString(key)
-				l.writer.WriteString("=\n")
 				if l.fieldColor != ColorOff {
-					writeIndent(l.writer, val, faintColor.Sprint("  | "))
+					l.writer.WriteString(faintColor.Sprint("=\n"))
+					writeIndent(l.writer, val, faintColor.Sprint(multiLinePrefix))
 				} else {
-					writeIndent(l.writer, val, "  | ")
+					l.writer.WriteString("=\n")
+					writeIndent(l.writer, val, multiLinePrefix)
 				}
 				l.writer.WriteString("  ")
 			} else if !raw && needsQuoting(val) {
 				l.writer.WriteByte(' ')
 				l.writer.WriteString(key)
-				l.writer.WriteByte('=')
+				if l.fieldColor != ColorOff {
+					l.writer.WriteString(faintColor.Sprint("="))
+				} else {
+					l.writer.WriteByte('=')
+				}
 				l.writer.WriteString(strconv.Quote(val))
 			} else {
 				l.writer.WriteByte(' ')
 				l.writer.WriteString(key)
-				l.writer.WriteByte('=')
+				if l.fieldColor != ColorOff {
+					l.writer.WriteString(faintColor.Sprint("="))
+				} else {
+					l.writer.WriteByte('=')
+				}
 				l.writer.WriteString(val)
 			}
 		}

--- a/intlogger.go
+++ b/intlogger.go
@@ -32,10 +32,6 @@ const TimeFormatJSON = "2006-01-02T15:04:05.000000Z07:00"
 // errJsonUnsupportedTypeMsg is included in log json entries, if an arg cannot be serialized to json
 const errJsonUnsupportedTypeMsg = "logging contained values that don't serialize to json"
 
-// multiLinePrefix is used for fields that contain multi-line values
-// when using non-JSON logging.
-const multiLinePrefix = "  | "
-
 var (
 	_levelToBracket = map[Level]string{
 		Debug: "[DEBUG]",
@@ -53,9 +49,11 @@ var (
 		Error: color.New(color.FgHiRed),
 	}
 
-	faintBoldColor       = color.New(color.Faint, color.Bold)
-	faintColor           = color.New(color.Faint)
-	faintMultiLinePrefix = faintColor.Sprint(multiLinePrefix)
+	faintBoldColor                 = color.New(color.Faint, color.Bold)
+	faintColor                     = color.New(color.Faint)
+	faintMultiLinePrefix           = faintColor.Sprint("  | ")
+	faintFieldSeparator            = faintColor.Sprint("=")
+	faintFieldSeparatorWithNewLine = faintColor.Sprint("=\n")
 )
 
 // Make sure that intLogger is a Logger
@@ -407,18 +405,18 @@ func (l *intLogger) logPlain(t time.Time, name string, level Level, msg string, 
 				l.writer.WriteString("\n  ")
 				l.writer.WriteString(key)
 				if l.fieldColor != ColorOff {
-					l.writer.WriteString(faintColor.Sprint("=\n"))
+					l.writer.WriteString(faintFieldSeparatorWithNewLine)
 					writeIndent(l.writer, val, faintMultiLinePrefix)
 				} else {
 					l.writer.WriteString("=\n")
-					writeIndent(l.writer, val, multiLinePrefix)
+					writeIndent(l.writer, val, "  | ")
 				}
 				l.writer.WriteString("  ")
 			} else if !raw && needsQuoting(val) {
 				l.writer.WriteByte(' ')
 				l.writer.WriteString(key)
 				if l.fieldColor != ColorOff {
-					l.writer.WriteString(faintColor.Sprint("="))
+					l.writer.WriteString(faintFieldSeparator)
 				} else {
 					l.writer.WriteByte('=')
 				}
@@ -427,7 +425,7 @@ func (l *intLogger) logPlain(t time.Time, name string, level Level, msg string, 
 				l.writer.WriteByte(' ')
 				l.writer.WriteString(key)
 				if l.fieldColor != ColorOff {
-					l.writer.WriteString(faintColor.Sprint("="))
+					l.writer.WriteString(faintFieldSeparator)
 				} else {
 					l.writer.WriteByte('=')
 				}

--- a/intlogger.go
+++ b/intlogger.go
@@ -48,6 +48,9 @@ var (
 		Warn:  color.New(color.FgHiYellow),
 		Error: color.New(color.FgHiRed),
 	}
+
+	faintBoldColor = color.New(color.Faint, color.Bold)
+	faintColor     = color.New(color.Faint)
 )
 
 // Make sure that intLogger is a Logger

--- a/logger.go
+++ b/logger.go
@@ -274,6 +274,10 @@ type LoggerOptions struct {
 	// Only color the header, not the body. This can help with readability of long messages.
 	ColorHeaderOnly bool
 
+	// Color the header and message body fields. This can help with readability
+	// of long messages with multiple fields.
+	ColorHeaderAndFields bool
+
 	// A function which is called with the log information and if it returns true the value
 	// should not be logged.
 	// This is useful when interacting with a system that you wish to suppress the log


### PR DESCRIPTION
This PR builds on https://github.com/hashicorp/go-hclog/pull/108, extending the ability to color fields as well as the level header.

When I have log lines with multiple fields (especially with long values), I find it hard to visually pinpoint the part of the log message I'm interested in. I think by dimming the `key=` part of the field, it'll be faster and easier to visually parse the information. For multi-line values, this will also dim the `|` prefix.

## Usage

```go
log := hclog.New(&hclog.LoggerOptions{
	Color:                hclog.AutoColor,
	ColorHeaderAndFields: true,
})
```
> **Note**: if [`ColorHeaderOnly`](https://github.com/hashicorp/go-hclog/blob/2a06ec98d67e4c2de59fb4cc7916c14ffbb91be6/logger.go#L275) is _also_ set as `true`, that takes precedence. 

### Before
<img width="565" alt="Screen Shot 2022-08-29 at 12 48 07 PM" src="https://user-images.githubusercontent.com/14850816/187252452-66caff63-bf08-43ec-a3d6-b8a7cf1e257c.png">


### After
<img width="573" alt="Screen Shot 2022-08-29 at 12 45 21 PM" src="https://user-images.githubusercontent.com/14850816/187252004-64c4cc01-9c29-443e-be2f-ac873a4e1a59.png">
