### PR TITLE
Improve AutoColor functionality

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        go-version: [1.14.x, 1.15.x, 1.16.x]
+        go-version: [1.14.x, 1.15.x, 1.16.x, 1.17.x, 1.18.x, 1.19.x]
         os: [ubuntu-latest, windows-latest, macOS-latest]
     steps:
       - name: Install Go

--- a/colorize_unix.go
+++ b/colorize_unix.go
@@ -7,23 +7,35 @@ import (
 	"github.com/mattn/go-isatty"
 )
 
+// hasFD is used to check if the writer has an Fd value to check
+// if it's a terminal.
+type hasFD interface {
+	Fd() uintptr
+}
+
 // setColorization will mutate the values of this logger
 // to appropriately configure colorization options. It provides
 // a wrapper to the output stream on Windows systems.
 func (l *intLogger) setColorization(opts *LoggerOptions) {
-	switch opts.Color {
-	case ColorOff:
-		fallthrough
-	case ForceColor:
+	if opts.Color != AutoColor {
 		return
-	case AutoColor:
-		fi := l.checkWriterIsFile()
-		isUnixTerm := isatty.IsTerminal(fi.Fd())
-		isCygwinTerm := isatty.IsCygwinTerminal(fi.Fd())
-		isTerm := isUnixTerm || isCygwinTerm
-		if !isTerm {
+	}
+
+	if sc, ok := l.writer.w.(SupportsColor); ok {
+		if !sc.SupportsColor() {
 			l.headerColor = ColorOff
 			l.writer.color = ColorOff
 		}
+		return
+	}
+
+	fi, ok := l.writer.w.(hasFD)
+	if !ok {
+		return
+	}
+
+	if !isatty.IsTerminal(fi.Fd()) {
+		l.headerColor = ColorOff
+		l.writer.color = ColorOff
 	}
 }

--- a/colorize_windows.go
+++ b/colorize_windows.go
@@ -7,32 +7,32 @@ import (
 	"os"
 
 	colorable "github.com/mattn/go-colorable"
-	"github.com/mattn/go-isatty"
 )
 
 // setColorization will mutate the values of this logger
 // to appropriately configure colorization options. It provides
 // a wrapper to the output stream on Windows systems.
 func (l *intLogger) setColorization(opts *LoggerOptions) {
-	switch opts.Color {
-	case ColorOff:
+	if opts.Color == ColorOff {
 		return
-	case ForceColor:
-		fi := l.checkWriterIsFile()
-		l.writer.w = colorable.NewColorable(fi)
-	case AutoColor:
-		fi := l.checkWriterIsFile()
-		isUnixTerm := isatty.IsTerminal(os.Stdout.Fd())
-		isCygwinTerm := isatty.IsCygwinTerminal(os.Stdout.Fd())
-		isTerm := isUnixTerm || isCygwinTerm
-		if !isTerm {
-			l.writer.color = ColorOff
-			l.headerColor = ColorOff
-			return
-		}
+	}
 
-		if l.headerColor == ColorOff {
-			l.writer.w = colorable.NewColorable(fi)
-		}
+	fi, ok := l.writer.w.(*os.File)
+	if !ok {
+		l.writer.color = ColorOff
+		l.headerColor = ColorOff
+		return
+	}
+
+	cfi := colorable.NewColorable(fi)
+
+	// NewColorable detects if color is possible and if it's not, then it
+	// returns the original value. So we can test if we got the original
+	// value back to know if color is possible.
+	if cfi == fi {
+		l.writer.color = ColorOff
+		l.headerColor = ColorOff
+	} else {
+		l.writer.w = cfi
 	}
 }

--- a/intlogger.go
+++ b/intlogger.go
@@ -8,7 +8,6 @@ import (
 	"fmt"
 	"io"
 	"log"
-	"os"
 	"reflect"
 	"runtime"
 	"sort"
@@ -874,16 +873,6 @@ func (l *intLogger) StandardWriter(opts *StandardLoggerOptions) io.Writer {
 		inferLevelsWithTimestamp: opts.InferLevelsWithTimestamp,
 		forceLevel:               opts.ForceLevel,
 	}
-}
-
-// checks if the underlying io.Writer is a file, and
-// panics if not. For use by colorization.
-func (l *intLogger) checkWriterIsFile() *os.File {
-	fi, ok := l.writer.w.(*os.File)
-	if !ok {
-		panic("Cannot enable coloring of non-file Writers")
-	}
-	return fi
 }
 
 // Accept implements the SinkAdapter interface

--- a/logger.go
+++ b/logger.go
@@ -89,6 +89,13 @@ const (
 	ForceColor
 )
 
+// SupportsColor is an optional interface that can be implemented by the output
+// value. If implemented and SupportsColor() returns true, then AutoColor will
+// enable colorization.
+type SupportsColor interface {
+	SupportsColor() bool
+}
+
 // LevelFromString returns a Level type for the named log level, or "NoLevel" if
 // the level string is invalid. This facilitates setting the log level via
 // config or environment variable by name in a predictable way.


### PR DESCRIPTION
Cleanup AutoColor to make it never fail, instead do it's best to activate color if possible only.

Fixes #122