### PR TITLE
Docs: InferLevelsWithTimestamp relies on InferLevels being true

### DIFF
--- a/README.md
+++ b/README.md
@@ -140,9 +140,10 @@ log.Printf("[DEBUG] %d", 42)
 ... [DEBUG] my-app: 42
 ```
 
-Notice that if `appLogger` is initialized with the `INFO` log level _and_ you
+Notice that if `appLogger` is initialized with the `INFO` log level, _and_ you
 specify `InferLevels: true`, you will not see any output here. You must change
 `appLogger` to `DEBUG` to see output. See the docs for more information.
 
 If the log lines start with a timestamp you can use the
-`InferLevelsWithTimestamp` option to try and ignore them.
+`InferLevelsWithTimestamp` option to try and ignore them. Please note that in order
+for `InferLevelsWithTimestamp` to be relevant, `InferLevels` must be set to `true`.

--- a/logger.go
+++ b/logger.go
@@ -233,6 +233,7 @@ type StandardLoggerOptions struct {
 	// [DEBUG] and strip it off before reapplying it.
 	// The timestamp detection may result in false positives and incomplete
 	// string outputs.
+	// InferLevelsWithTimestamp is only relevant if InferLevels is true.
 	InferLevelsWithTimestamp bool
 
 	// ForceLevel is used to force all output from the standard logger to be at


### PR DESCRIPTION
This PR is a tiny docs update for the go doc around `InferLevelsWithTimestamp`.

The idea is to stop people running into a gotcha I experienced recently where `InferLevels` must be `true` in order for the `InferLevelsWithTimestamp` setting to have any impact.