### PR TITLE
Fix colors not being forced on correctly.

### DIFF
--- a/intlogger.go
+++ b/intlogger.go
@@ -55,10 +55,24 @@ var (
 
 	faintBoldColor                 = color.New(color.Faint, color.Bold)
 	faintColor                     = color.New(color.Faint)
-	faintMultiLinePrefix           = faintColor.Sprint("  | ")
-	faintFieldSeparator            = faintColor.Sprint("=")
-	faintFieldSeparatorWithNewLine = faintColor.Sprint("=\n")
+	faintMultiLinePrefix           string
+	faintFieldSeparator            string
+	faintFieldSeparatorWithNewLine string
 )
+
+func init() {
+	// Force all the colors to enabled because we do our own detection of color usage.
+	for _, c := range _levelToColor {
+		c.EnableColor()
+	}
+
+	faintBoldColor.EnableColor()
+	faintColor.EnableColor()
+
+	faintMultiLinePrefix = faintColor.Sprint("  | ")
+	faintFieldSeparator = faintColor.Sprint("=")
+	faintFieldSeparatorWithNewLine = faintColor.Sprint("=\n")
+}
 
 // Make sure that intLogger is a Logger
 var _ Logger = &intLogger{}

--- a/logger_test.go
+++ b/logger_test.go
@@ -257,6 +257,34 @@ func TestLogger(t *testing.T) {
 		assert.Equal(t, "[INFO]  sublogger: this is test\n", rest)
 	})
 
+	t.Run("colorize", func(t *testing.T) {
+		var buf bytes.Buffer
+
+		logger := New(&LoggerOptions{
+			// No name!
+			Output:     &buf,
+			Level:      Trace,
+			Color:      ForceColor,
+			TimeFormat: "<time>",
+		})
+
+		logger.Trace("trace")
+		logger.Debug("debug")
+		logger.Info("info")
+		logger.Warn("warn")
+		logger.Error("error")
+		str := buf.String()
+
+		assert.Equal(t, ""+
+			"\033[92m<time> [TRACE] trace\n\033[0m"+
+			"\033[97m<time> [DEBUG] debug\n\033[0m"+
+			"\033[94m<time> [INFO]  info\n\033[0m"+
+			"\033[93m<time> [WARN]  warn\n\033[0m"+
+			"\033[91m<time> [ERROR] error\n\033[0m",
+			str,
+		)
+	})
+
 	t.Run("use a different time format", func(t *testing.T) {
 		var buf bytes.Buffer
 

--- a/logger_test.go
+++ b/logger_test.go
@@ -258,6 +258,10 @@ func TestLogger(t *testing.T) {
 	})
 
 	t.Run("can force colors to on in any context", func(t *testing.T) {
+		if runtime.GOOS == "windows" {
+			t.Skip("colors are different on windows")
+		}
+
 		var buf bytes.Buffer
 
 		logger := New(&LoggerOptions{

--- a/logger_test.go
+++ b/logger_test.go
@@ -257,7 +257,7 @@ func TestLogger(t *testing.T) {
 		assert.Equal(t, "[INFO]  sublogger: this is test\n", rest)
 	})
 
-	t.Run("colorize", func(t *testing.T) {
+	t.Run("can force colors to on in any context", func(t *testing.T) {
 		var buf bytes.Buffer
 
 		logger := New(&LoggerOptions{


### PR DESCRIPTION
Turns out that the color package we use was doing it's own "should
colors be on or not" detection, which interferred with our own
detection. This caused situations where colors were forced on to still
be off (and, maddeningly, would show up in weird contexts because it
dependent on Stdout being not a terminal to break when forced).

Fixes #127 
Closes #131 