### PR TITLE
hclogvet: updates for go1.22

### DIFF
--- a/hclogvet/go.mod
+++ b/hclogvet/go.mod
@@ -1,10 +1,7 @@
 module github.com/hashicorp/go-hclog/hclogvet
 
-go 1.20
+go 1.22
 
-require golang.org/x/tools v0.5.0
+require golang.org/x/tools v0.18.0
 
-require (
-	golang.org/x/mod v0.7.0 // indirect
-	golang.org/x/sys v0.4.0 // indirect
-)
+require golang.org/x/mod v0.15.0 // indirect

--- a/hclogvet/go.sum
+++ b/hclogvet/go.sum
@@ -1,7 +1,6 @@
-golang.org/x/mod v0.7.0 h1:LapD9S96VoQRhi/GrNTqeBJFrUjs5UHCAtTlgwA5oZA=
-golang.org/x/mod v0.7.0/go.mod h1:iBbtSCu2XBx23ZKBPSOrRkjjQPZFPuis4dIYUhu/chs=
-golang.org/x/sync v0.1.0 h1:wsuoTGHzEhffawBOhz5CYhcrV4IdKZbEyZjBMuTp12o=
-golang.org/x/sys v0.4.0 h1:Zr2JFtRQNX3BCZ8YtxRE9hNJYC8J6I1MVbMg6owUp18=
-golang.org/x/sys v0.4.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
-golang.org/x/tools v0.5.0 h1:+bSpV5HIeWkuvgaMfI3UmKRThoTA5ODJTUd8T17NO+4=
-golang.org/x/tools v0.5.0/go.mod h1:N+Kgy78s5I24c24dU8OfWNEotWjutIs8SnJvn5IDq+k=
+golang.org/x/mod v0.15.0 h1:SernR4v+D55NyBH2QiEQrlBAnj1ECL6AGrA5+dPaMY8=
+golang.org/x/mod v0.15.0/go.mod h1:hTbmBsO62+eylJbnUtE2MGJUyE7QWk4xUqPFrRgJ+7c=
+golang.org/x/sync v0.6.0 h1:5BMeUDZ7vkXGfEr1x9B4bRcTH4lpkTkpdh0T/J+qjbQ=
+golang.org/x/sync v0.6.0/go.mod h1:Czt+wKu1gCyEFDUtn0jG5QVvpJ6rzVqr5aXyt9drQfk=
+golang.org/x/tools v0.18.0 h1:k8NLag8AGHnn+PHbl7g43CtqZAwG60vZkLqgyZgIHgQ=
+golang.org/x/tools v0.18.0/go.mod h1:GL7B4CwcLLeo59yx/9UWWuNOW1n3VZ4f5axWfML7Lcg=


### PR DESCRIPTION
fixes panic due to go1.22 incompats

```
==> Linting hclog statements...
panic: runtime error: invalid memory address or nil pointer dereference [recovered]
        panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x0 pc=0x59351e]

goroutine 14 [running]:
go/types.(*Checker).handleBailout(0xc0004c9c00, 0xc0023f5c10)
        /opt/google/go/src/go/types/check.go:367 +0x88
panic({0x70ef40?, 0x991a80?})
        /opt/google/go/src/runtime/panic.go:770 +0x132
go/types.(*StdSizes).Sizeof(0x0, {0x7db790, 0x995620})
        /opt/google/go/src/go/types/sizes.go:228 +0x31e
go/types.(*Config).sizeof(...)
        /opt/google/go/src/go/types/sizes.go:333
go/types.representableConst.func1({0x7db790?, 0x995620?})
        /opt/google/go/src/go/types/const.go:76 +0x9e
go/types.representableConst({0x7dccc8, 0x98a388}, 0xc0004c9c00, 0x995620, 0xc0023f1c88)
        /opt/google/go/src/go/types/const.go:92 +0x192
```