### PR TITLE
Begin v2 of the API, fixes memory usage

### DIFF
--- a/context.go
+++ b/context.go
@@ -27,7 +27,7 @@ func WithContext(ctx context.Context, logger Logger, args ...interface{}) contex
 // this will never return a nil value.
 func FromContext(ctx context.Context) Logger {
 	logger, _ := ctx.Value(contextKey).(Logger)
-	if logger == nil {
+	if logger.impl == nil {
 		return L()
 	}
 

--- a/global.go
+++ b/global.go
@@ -36,7 +36,7 @@ func Default() Logger {
 	protect.Do(func() {
 		// If SetDefault was used before Default() was called, we need to
 		// detect that here.
-		if def == nil {
+		if def.impl == nil {
 			def = New(DefaultOptions)
 		}
 	})

--- a/intlogger.go
+++ b/intlogger.go
@@ -75,7 +75,7 @@ func init() {
 }
 
 // Make sure that intLogger is a Logger
-var _ Logger = &intLogger{}
+var _ LogImpl = &intLogger{}
 
 // intLogger is an internal logger implementation. Internal in that it is
 // defined entirely by this package.
@@ -117,12 +117,14 @@ type intLogger struct {
 	independentLevels bool
 	syncParentLevel   bool
 
-	subloggerHook func(sub Logger) Logger
+	subloggerHook func(sub LogImpl) LogImpl
 }
 
 // New returns a configured logger.
 func New(opts *LoggerOptions) Logger {
-	return newLogger(opts)
+	return Logger{
+		impl: newLogger(opts),
+	}
 }
 
 // NewSinkAdapter returns a SinkAdapter with configured settings
@@ -213,13 +215,13 @@ func newLogger(opts *LoggerOptions) *intLogger {
 	return l
 }
 
-func identityHook(logger Logger) Logger {
+func identityHook(logger LogImpl) LogImpl {
 	return logger
 }
 
 // offsetIntLogger is the stack frame offset in the call stack for the caller to
 // one of the Warn, Info, Log, etc methods.
-const offsetIntLogger = 3
+const offsetIntLogger = 4
 
 // Log a message and a set of key/value pairs if the given level is at
 // or more severe that the threshold configured in the Logger.
@@ -721,6 +723,11 @@ func (l *intLogger) Log(level Level, msg string, args ...interface{}) {
 	l.log(l.Name(), level, msg, args...)
 }
 
+// Emit the message and args at the provided level
+func (l *intLogger) LogRecord(r Record) {
+	l.log(l.Name(), r.Level, r.Msg, r.Args...)
+}
+
 // Emit the message and args at DEBUG level
 func (l *intLogger) Debug(msg string, args ...interface{}) {
 	l.log(l.Name(), Debug, msg, args...)
@@ -776,7 +783,7 @@ const MissingKey = "EXTRA_VALUE_AT_END"
 // Return a sub-Logger for which every emitted log message will contain
 // the given key/value pairs. This is used to create a context specific
 // Logger.
-func (l *intLogger) With(args ...interface{}) Logger {
+func (l *intLogger) With(args ...interface{}) LogImpl {
 	var extra interface{}
 
 	if len(args)%2 != 0 {
@@ -823,7 +830,7 @@ func (l *intLogger) With(args ...interface{}) Logger {
 
 // Create a new sub-Logger that a name decending from the current name.
 // This is used to create a subsystem specific Logger.
-func (l *intLogger) Named(name string) Logger {
+func (l *intLogger) Named(name string) LogImpl {
 	sl := l.copy()
 
 	if sl.name != "" {
@@ -838,7 +845,7 @@ func (l *intLogger) Named(name string) Logger {
 // Create a new sub-Logger with an explicit name. This ignores the current
 // name. This is used to create a standalone logger that doesn't fall
 // within the normal hierarchy.
-func (l *intLogger) ResetNamed(name string) Logger {
+func (l *intLogger) ResetNamed(name string) LogImpl {
 	sl := l.copy()
 
 	sl.name = name

--- a/logger.go
+++ b/logger.go
@@ -144,13 +144,15 @@ func (l Level) String() string {
 	}
 }
 
-// Logger describes the interface that must be implemented by all loggers.
-type Logger interface {
+// LogImpl describes the interface that must be implemented by all loggers.
+type LogImpl interface {
 	// Args are alternating key, val pairs
 	// keys must be strings
 	// vals can be any type, but display is implementation specific
 	// Emit a message and key/value pairs at a provided log level
 	Log(level Level, msg string, args ...interface{})
+
+	LogRecord(Record)
 
 	// Emit a message and key/value pairs at the TRACE level
 	Trace(msg string, args ...interface{})
@@ -187,7 +189,7 @@ type Logger interface {
 	ImpliedArgs() []interface{}
 
 	// Creates a sublogger that will always have the given key/value pairs
-	With(args ...interface{}) Logger
+	With(args ...interface{}) LogImpl
 
 	// Returns the Name of the logger
 	Name() string
@@ -196,12 +198,12 @@ type Logger interface {
 	// If the logger already has a name, the new value will be appended to the current
 	// name. That way, a major subsystem can use this to decorate all it's own logs
 	// without losing context.
-	Named(name string) Logger
+	Named(name string) LogImpl
 
 	// Create a logger that will prepend the name string on the front of all messages.
 	// This sets the name of the logger to the value directly, unlike Named which honor
 	// the current name as well.
-	ResetNamed(name string) Logger
+	ResetNamed(name string) LogImpl
 
 	// Updates the level. This should affect all related loggers as well,
 	// unless they were created with IndependentLevels. If an
@@ -327,7 +329,7 @@ type LoggerOptions struct {
 	// the newly created Logger and the returned Logger is returned from the
 	// original function. This option allows customization via interception and
 	// wrapping of Logger instances.
-	SubloggerHook func(sub Logger) Logger
+	SubloggerHook func(sub LogImpl) LogImpl
 }
 
 // InterceptLogger describes the interface for using a logger
@@ -337,7 +339,7 @@ type LoggerOptions struct {
 // at a higher one.
 type InterceptLogger interface {
 	// Logger is the root logger for an InterceptLogger
-	Logger
+	LogImpl
 
 	// RegisterSink adds a SinkAdapter to the InterceptLogger
 	RegisterSink(sink SinkAdapter)

--- a/logger_test.go
+++ b/logger_test.go
@@ -538,7 +538,7 @@ func TestLogger(t *testing.T) {
 
 		assert.Equal(t, "[INFO]  this is test: production=\"12 beans/day\"\n", rest)
 
-		logger.(OutputResettable).ResetOutput(&LoggerOptions{
+		logger.impl.(OutputResettable).ResetOutput(&LoggerOptions{
 			Output: &second,
 		})
 
@@ -568,7 +568,7 @@ func TestLogger(t *testing.T) {
 		str := first.String()
 		assert.Empty(t, str)
 
-		logger.(OutputResettable).ResetOutputWithFlush(&LoggerOptions{
+		logger.impl.(OutputResettable).ResetOutputWithFlush(&LoggerOptions{
 			Output: &second,
 		}, &first)
 

--- a/memory_test.go
+++ b/memory_test.go
@@ -25,3 +25,28 @@ func BenchmarkLoggerMemory(b *testing.B) {
 		}
 	}
 }
+
+func TestLoggerMemory(t *testing.T) {
+	var buf bytes.Buffer
+
+	logger := New(&LoggerOptions{
+		Name:   "test",
+		Output: &buf,
+		Level:  Info,
+	})
+
+	avg := testing.AllocsPerRun(100, func() {
+		logger.Trace("this is some message",
+			"name", "foo",
+			"what", "benchmarking yourself",
+		)
+
+		if buf.Len() != 0 {
+			panic("oops")
+		}
+	})
+
+	if avg != 0 {
+		t.Fatalf("ignored logs allocated")
+	}
+}

--- a/memory_test.go
+++ b/memory_test.go
@@ -1,0 +1,27 @@
+package hclog
+
+import (
+	"bytes"
+	"testing"
+)
+
+func BenchmarkLoggerMemory(b *testing.B) {
+	var buf bytes.Buffer
+
+	logger := New(&LoggerOptions{
+		Name:   "test",
+		Output: &buf,
+		Level:  Info,
+	})
+
+	for i := 0; i < b.N; i++ {
+		logger.Trace("this is some message",
+			"name", "foo",
+			"what", "benchmarking yourself",
+		)
+
+		if buf.Len() != 0 {
+			panic("oops")
+		}
+	}
+}

--- a/nulllogger.go
+++ b/nulllogger.go
@@ -12,13 +12,14 @@ import (
 // NewNullLogger instantiates a Logger for which all calls
 // will succeed without doing anything.
 // Useful for testing purposes.
-func NewNullLogger() Logger {
+func NewNullLogger() LogImpl {
 	return &nullLogger{}
 }
 
 type nullLogger struct{}
 
 func (l *nullLogger) Log(level Level, msg string, args ...interface{}) {}
+func (l *nullLogger) LogRecord(r Record)                               {}
 
 func (l *nullLogger) Trace(msg string, args ...interface{}) {}
 
@@ -42,13 +43,13 @@ func (l *nullLogger) IsError() bool { return false }
 
 func (l *nullLogger) ImpliedArgs() []interface{} { return []interface{}{} }
 
-func (l *nullLogger) With(args ...interface{}) Logger { return l }
+func (l *nullLogger) With(args ...interface{}) LogImpl { return l }
 
 func (l *nullLogger) Name() string { return "" }
 
-func (l *nullLogger) Named(name string) Logger { return l }
+func (l *nullLogger) Named(name string) LogImpl { return l }
 
-func (l *nullLogger) ResetNamed(name string) Logger { return l }
+func (l *nullLogger) ResetNamed(name string) LogImpl { return l }
 
 func (l *nullLogger) SetLevel(level Level) {}
 

--- a/record.go
+++ b/record.go
@@ -1,0 +1,22 @@
+package hclog
+
+const inlineArgs = 10
+
+type Record struct {
+	Level    Level
+	Msg      string
+	CallerPc uintptr
+
+	inline [inlineArgs]interface{}
+	Args   []interface{}
+}
+
+func (r *Record) SetArgs(args []interface{}) {
+	if len(args) > inlineArgs {
+		r.Args = make([]interface{}, len(args))
+		copy(r.Args, args)
+	} else {
+		copy(r.inline[:], args)
+		r.Args = r.inline[:]
+	}
+}

--- a/stdlog.go
+++ b/stdlog.go
@@ -18,7 +18,7 @@ var logTimestampRegexp = regexp.MustCompile(`^[\d\s\:\/\.\+-TZ]*`)
 // and back into our Logger. This is basically the only way to
 // build upon *log.Logger.
 type stdlogAdapter struct {
-	log                      Logger
+	log                      LogImpl
 	inferLevels              bool
 	inferLevelsWithTimestamp bool
 	forceLevel               Level

--- a/stdlog_test.go
+++ b/stdlog_test.go
@@ -206,7 +206,7 @@ func TestStdlogAdapter_ForceLevel(t *testing.T) {
 			})
 
 			s := &stdlogAdapter{
-				log:         logger,
+				log:         logger.impl,
 				forceLevel:  c.forceLevel,
 				inferLevels: c.inferLevels,
 			}

--- a/value.go
+++ b/value.go
@@ -1,0 +1,113 @@
+package hclog
+
+import (
+	"runtime"
+)
+
+type Logger struct {
+	impl LogImpl
+}
+
+func (v *Logger) log(level Level, msg string, args ...interface{}) {
+	if level < v.impl.GetLevel() {
+		return
+	}
+
+	var pc uintptr
+	var pcs [1]uintptr
+	// skip [runtime.Callers, this function, this function's caller]
+	runtime.Callers(3, pcs[:])
+	pc = pcs[0]
+
+	r := Record{
+		Level:    level,
+		Msg:      msg,
+		CallerPc: pc,
+	}
+
+	r.SetArgs(args)
+
+	v.impl.LogRecord(r)
+}
+
+// Emit the message and args at the given level
+func (v *Logger) Log(level Level, msg string, args ...interface{}) {
+	v.log(level, msg, args...)
+}
+
+// Emit the message and args at TRACE level
+func (v *Logger) Trace(msg string, args ...interface{}) {
+	v.log(Trace, msg, args...)
+}
+
+// Emit the message and args at DEBUG level
+func (v *Logger) Debug(msg string, args ...interface{}) {
+	v.log(Debug, msg, args...)
+}
+
+// Emit the message and args at INFO level
+func (v *Logger) Info(msg string, args ...interface{}) {
+	v.log(Info, msg, args...)
+}
+
+// Emit the message and args at WARN level
+func (v *Logger) Warn(msg string, args ...interface{}) {
+	v.log(Warn, msg, args...)
+}
+
+// Emit the message and args at ERROR level
+func (v Logger) Error(msg string, args ...interface{}) {
+	v.log(Error, msg, args...)
+}
+
+func (v Logger) IsTrace() bool {
+	return Debug >= v.impl.GetLevel()
+}
+
+func (v Logger) IsDebug() bool {
+	return Debug >= v.impl.GetLevel()
+}
+
+func (v Logger) IsInfo() bool {
+	return Debug >= v.impl.GetLevel()
+}
+
+func (v Logger) IsWarn() bool {
+	return Debug >= v.impl.GetLevel()
+}
+
+func (v Logger) IsError() bool {
+	return Debug >= v.impl.GetLevel()
+}
+
+func (v Logger) Named(name string) Logger {
+	return Logger{
+		v.impl.Named(name),
+	}
+}
+
+func (v Logger) ResetNamed(name string) Logger {
+	return Logger{
+		v.impl.ResetNamed(name),
+	}
+}
+
+func (v Logger) With(args ...interface{}) Logger {
+	return Logger{
+		v.impl.With(args...),
+	}
+}
+
+func (v *Logger) SetLevel(level Level) {
+	v.impl.SetLevel(level)
+}
+
+func (v *Logger) GetLevel() Level {
+	return v.impl.GetLevel()
+}
+
+func AsValue(log LogImpl) Logger {
+	return Logger{
+		impl: log,
+	}
+}


### PR DESCRIPTION
While hunting down some memory usage issues elsewhere, I saw that, much to my chagrin, hclog was suffering from the exact memory issue issue that `log/slog` was designed to avoid: memory usage when the log is ignored.

As Jonathan Amsterdam points out extremely well in his presentations of slog, Go is unable to elide a ... generated slice when calling an interface function. This makes completely sense, given it has to assume it could dispatch to any number of targets.

Following in the same pattern used in slog, this PR begins a minor (but breaking) API change to correct the issue in hclog. By making Logger a struct value (that can be used as a pointer or not, it's no matter) and performing level checking before dispatching to the interface, the memory usage is elided correctly.

The benchmark included shows the memory fix as it now reports:

```
BenchmarkLoggerMemory-10        250033984                5.027 ns/op           0 B/op          0 allocs/op
```

Where as previously, it reports:

```
BenchmarkLoggerMemory-10        40523308                30.87 ns/op           64 B/op          1 allocs/op
```

There is more work to be done if we approve of this going forward, for instance, using the same technique slog uses to clean up the line calculation.

Here is Jonathan talking all about the issue that this v2 API would fix: https://youtu.be/8rnI2xLrdeM?t=1491