### PR TITLE
support configure json escape when log in json format

### DIFF
--- a/logger.go
+++ b/logger.go
@@ -264,6 +264,9 @@ type LoggerOptions struct {
 	// Control if the output should be in JSON.
 	JSONFormat bool
 
+	// Control the escape switch of json.Encoder
+	JSONEscapeDisabled bool
+
 	// Include file and line information in each log line
 	IncludeLocation bool
 

--- a/logger_test.go
+++ b/logger_test.go
@@ -1232,6 +1232,28 @@ func TestLogger_JSON(t *testing.T) {
 		assert.Equal(t, "[INFO]  test: who=programmer why=testing\n", rest)
 	})
 
+	t.Run("disable json escape when log special character", func(t *testing.T) {
+		var buf bytes.Buffer
+
+		logger := New(&LoggerOptions{
+			Name:               "test",
+			Output:             &buf,
+			JSONFormat:         true,
+			JSONEscapeDisabled: true,
+		})
+
+		logger.Info("this is test and use > < &")
+
+		b := buf.Bytes()
+
+		var raw map[string]interface{}
+		if err := json.Unmarshal(b, &raw); err != nil {
+			t.Fatal(err)
+		}
+
+		assert.Equal(t, "this is test and use > < &", raw["@message"])
+	})
+
 }
 
 type customErrJSON struct {


### PR DESCRIPTION
To resolve #140 

This modification will not lead to some breaking change, because the attribute which added will default to false. If user want to use this feat, this attribute should be set to true.