### PR TITLE
Support `FromStandardSLogger` to wrap a `slog.Logger` into a `hclog.Logger`

### DIFF
--- a/stdslog.go
+++ b/stdslog.go
@@ -1,0 +1,219 @@
+package hclog
+
+import (
+	"context"
+	"io"
+	"log"
+	"log/slog"
+	"sort"
+	"strings"
+)
+
+type stdslogWrapper struct {
+	slog    *slog.Logger
+	oriSlog *slog.Logger
+	lvar    *slog.LevelVar
+	names   []string
+	args    []interface{}
+}
+
+func (s *stdslogWrapper) clone() *stdslogWrapper {
+	newSlog := *s.slog
+	var oriSlog *slog.Logger = nil
+	if s.oriSlog != nil {
+		newOriSlog := *s.oriSlog
+		oriSlog = &newOriSlog
+	}
+	return &stdslogWrapper{
+		slog:    &newSlog,
+		oriSlog: oriSlog,
+		names:   append([]string{}, s.names...),
+		args:    append([]interface{}{}, s.args...),
+	}
+}
+
+var _ Logger = &stdslogWrapper{}
+
+const (
+	SlogLevelTrace = slog.LevelDebug - 4
+	SlogLevelOff   = slog.LevelError + 4
+)
+
+var levelMapToSlog = map[Level]slog.Level{
+	Off:   SlogLevelOff,
+	Error: slog.LevelError,
+	Warn:  slog.LevelWarn,
+	Info:  slog.LevelInfo,
+	Debug: slog.LevelDebug,
+	Trace: SlogLevelTrace,
+}
+
+var levelMapFromSlog = map[slog.Level]Level{
+	SlogLevelOff:    Off,
+	slog.LevelError: Error,
+	slog.LevelWarn:  Warn,
+	slog.LevelInfo:  Info,
+	slog.LevelDebug: Debug,
+	SlogLevelTrace:  Trace,
+}
+
+// New wraps a slog.Logger to a Logger.
+// The `SetLevel` method only works when the `lvar` is specified and set to the slog.Logger.
+func FromStandardSLogger(l *slog.Logger, lvar *slog.LevelVar) Logger {
+	return &stdslogWrapper{
+		slog:    l,
+		oriSlog: nil,
+		lvar:    lvar,
+		names:   []string{},
+		args:    []interface{}{},
+	}
+}
+
+func (s *stdslogWrapper) Trace(msg string, args ...interface{}) {
+	s.slog.Log(context.Background(), SlogLevelTrace, msg, args...)
+}
+
+func (s *stdslogWrapper) Debug(msg string, args ...interface{}) {
+	s.slog.Debug(msg, args...)
+}
+
+func (s *stdslogWrapper) Info(msg string, args ...interface{}) {
+	s.slog.Info(msg, args...)
+}
+
+func (s *stdslogWrapper) Warn(msg string, args ...interface{}) {
+	s.slog.Warn(msg, args...)
+}
+
+func (s *stdslogWrapper) Error(msg string, args ...interface{}) {
+	s.slog.Error(msg, args...)
+}
+
+func (s *stdslogWrapper) GetLevel() Level {
+	if s.lvar == nil {
+		// lvar not set indicates the source slog.Logger has a fixed log level (or a default level, which equals to Info).
+		// In this case, we enumerate the log levels from lowest (Trace) to get the effective log level.
+		return s.getLowestLevel()
+	}
+	return levelMapFromSlog[s.lvar.Level()]
+}
+
+// SetLevel only applies when the source slog.Logger has a slog.LevelVar level.
+func (s *stdslogWrapper) SetLevel(level Level) {
+	if s.lvar != nil {
+		s.lvar.Set(levelMapToSlog[level])
+	}
+}
+
+func (s *stdslogWrapper) IsTrace() bool {
+	return s.slog.Enabled(context.Background(), SlogLevelTrace)
+}
+
+func (s *stdslogWrapper) IsDebug() bool {
+	return s.slog.Enabled(context.Background(), slog.LevelDebug)
+}
+
+func (s *stdslogWrapper) IsInfo() bool {
+	return s.slog.Enabled(context.Background(), slog.LevelInfo)
+}
+
+func (s *stdslogWrapper) IsWarn() bool {
+	return s.slog.Enabled(context.Background(), slog.LevelWarn)
+}
+
+func (s *stdslogWrapper) IsError() bool {
+	return s.slog.Enabled(context.Background(), slog.LevelError)
+}
+
+func (s *stdslogWrapper) Log(level Level, msg string, args ...interface{}) {
+	s.slog.Log(context.Background(), levelMapToSlog[level], msg, args...)
+}
+
+func (s *stdslogWrapper) Name() string {
+	return strings.Join(s.names, ".")
+}
+
+func (s *stdslogWrapper) Named(name string) Logger {
+	sl := s.clone()
+	if len(s.names) == 0 {
+		newSlog := *sl.slog
+		sl.oriSlog = &newSlog
+	}
+	sl.names = append(sl.names, name)
+	sl.slog = s.slog.WithGroup(name)
+	return sl
+}
+
+func (s *stdslogWrapper) ResetNamed(name string) Logger {
+	sl := s.clone()
+
+	// Empty name indicates to clear the name
+	if name == "" {
+		if len(sl.names) == 0 {
+			return sl
+		}
+		sl.names = []string{}
+		sl.slog = sl.oriSlog
+		sl.oriSlog = nil
+		return sl
+	}
+
+	// Non-empty name indicates to set the name
+	if len(sl.names) == 0 {
+		return sl.Named(name)
+	}
+	sl.names = []string{}
+	sl.slog = sl.oriSlog
+	sl.oriSlog = nil
+	return sl.Named(name)
+}
+
+func (s *stdslogWrapper) With(args ...interface{}) Logger {
+	sl := s.clone()
+	sl.slog = s.slog.With(args...)
+	sl.args = append(sl.args, args...)
+	return sl
+}
+
+func (s *stdslogWrapper) ImpliedArgs() []interface{} {
+	return s.args
+}
+
+func (s *stdslogWrapper) StandardLogger(opts *StandardLoggerOptions) *log.Logger {
+	if opts == nil {
+		opts = &StandardLoggerOptions{}
+	}
+
+	return log.New(s.StandardWriter(opts), "", 0)
+}
+
+func (s *stdslogWrapper) StandardWriter(opts *StandardLoggerOptions) io.Writer {
+	newLog := s.clone()
+	return &stdlogAdapter{
+		log:                      newLog,
+		inferLevels:              opts.InferLevels,
+		inferLevelsWithTimestamp: opts.InferLevelsWithTimestamp,
+		forceLevel:               opts.ForceLevel,
+	}
+}
+
+func (s *stdslogWrapper) getLowestLevel() Level {
+	ctx := context.Background()
+
+	var slogLvls []slog.Level
+	for lvlSlog := range levelMapFromSlog {
+		slogLvls = append(slogLvls, lvlSlog)
+	}
+	// Sort the slog levels from Trace up to Error
+	sort.Slice(slogLvls, func(i, j int) bool {
+		return int(slogLvls[i]) < int(slogLvls[j])
+	})
+
+	for _, lvlSlog := range slogLvls {
+		lvl := levelMapFromSlog[lvlSlog]
+		if s.slog.Enabled(ctx, lvlSlog) {
+			return lvl
+		}
+	}
+	return Off
+}

--- a/stdslog_test.go
+++ b/stdslog_test.go
@@ -1,0 +1,217 @@
+package hclog
+
+import (
+	"bytes"
+	"log/slog"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestFromStandardSLogger(t *testing.T) {
+	newSimple := func(level slog.Leveler, buf *bytes.Buffer) Logger {
+		var lvar *slog.LevelVar = nil
+		if v, ok := level.(*slog.LevelVar); ok {
+			lvar = v
+		}
+		return FromStandardSLogger(slog.New(slog.NewTextHandler(buf, &slog.HandlerOptions{
+			Level: level,
+			ReplaceAttr: func(groups []string, a slog.Attr) slog.Attr {
+				if a.Key == slog.TimeKey {
+					return slog.Attr{}
+				}
+				return a
+			},
+		})), lvar)
+	}
+	t.Run("trace", func(t *testing.T) {
+		var buf bytes.Buffer
+		logger := newSimple(SlogLevelTrace, &buf)
+		logger.Trace("this is test", "who", "programmer", "why", "testing")
+		assert.Equal(t, "level=DEBUG-4 msg=\"this is test\" who=programmer why=testing\n", buf.String())
+
+		assert.Equal(t, Trace, logger.GetLevel())
+		assert.Equal(t, true, logger.IsTrace())
+		assert.Equal(t, true, logger.IsDebug())
+		assert.Equal(t, true, logger.IsInfo())
+		assert.Equal(t, true, logger.IsWarn())
+		assert.Equal(t, true, logger.IsError())
+	})
+	t.Run("debug", func(t *testing.T) {
+		var buf bytes.Buffer
+		logger := newSimple(slog.LevelDebug, &buf)
+		logger.Debug("this is test", "who", "programmer", "why", "testing")
+		assert.Equal(t, "level=DEBUG msg=\"this is test\" who=programmer why=testing\n", buf.String())
+
+		assert.Equal(t, Debug, logger.GetLevel())
+		assert.Equal(t, false, logger.IsTrace())
+		assert.Equal(t, true, logger.IsDebug())
+		assert.Equal(t, true, logger.IsInfo())
+		assert.Equal(t, true, logger.IsWarn())
+		assert.Equal(t, true, logger.IsError())
+	})
+	t.Run("info", func(t *testing.T) {
+		var buf bytes.Buffer
+		logger := newSimple(slog.LevelInfo, &buf)
+		logger.Info("this is test", "who", "programmer", "why", "testing")
+		assert.Equal(t, "level=INFO msg=\"this is test\" who=programmer why=testing\n", buf.String())
+
+		assert.Equal(t, Info, logger.GetLevel())
+		assert.Equal(t, false, logger.IsTrace())
+		assert.Equal(t, false, logger.IsDebug())
+		assert.Equal(t, true, logger.IsInfo())
+		assert.Equal(t, true, logger.IsWarn())
+		assert.Equal(t, true, logger.IsError())
+	})
+	t.Run("warn", func(t *testing.T) {
+		var buf bytes.Buffer
+		logger := newSimple(slog.LevelWarn, &buf)
+		logger.Warn("this is test", "who", "programmer", "why", "testing")
+		assert.Equal(t, "level=WARN msg=\"this is test\" who=programmer why=testing\n", buf.String())
+
+		assert.Equal(t, Warn, logger.GetLevel())
+		assert.Equal(t, false, logger.IsTrace())
+		assert.Equal(t, false, logger.IsDebug())
+		assert.Equal(t, false, logger.IsInfo())
+		assert.Equal(t, true, logger.IsWarn())
+		assert.Equal(t, true, logger.IsError())
+	})
+	t.Run("error", func(t *testing.T) {
+		var buf bytes.Buffer
+		logger := newSimple(slog.LevelError, &buf)
+		logger.Error("this is test", "who", "programmer", "why", "testing")
+		assert.Equal(t, "level=ERROR msg=\"this is test\" who=programmer why=testing\n", buf.String())
+
+		assert.Equal(t, Error, logger.GetLevel())
+		assert.Equal(t, false, logger.IsTrace())
+		assert.Equal(t, false, logger.IsDebug())
+		assert.Equal(t, false, logger.IsInfo())
+		assert.Equal(t, false, logger.IsWarn())
+		assert.Equal(t, true, logger.IsError())
+	})
+	t.Run("off", func(t *testing.T) {
+		var buf bytes.Buffer
+		logger := newSimple(SlogLevelOff, &buf)
+		logger.Error("this is test", "who", "programmer", "why", "testing")
+		assert.Equal(t, 0, buf.Len())
+
+		assert.Equal(t, Off, logger.GetLevel())
+		assert.Equal(t, false, logger.IsTrace())
+		assert.Equal(t, false, logger.IsDebug())
+		assert.Equal(t, false, logger.IsInfo())
+		assert.Equal(t, false, logger.IsWarn())
+		assert.Equal(t, false, logger.IsError())
+	})
+	t.Run("var level", func(t *testing.T) {
+		var buf bytes.Buffer
+		var lvar slog.LevelVar
+		logger := newSimple(&lvar, &buf)
+
+		// Default LevelVar is Info, so it won't log trace msg
+		logger.Trace("trace msg")
+		assert.Equal(t, 0, buf.Len())
+		assert.Equal(t, Info, logger.GetLevel())
+
+		// Info message is logged
+		logger.Info("info msg")
+		assert.Equal(t, "level=INFO msg=\"info msg\"\n", buf.String())
+		assert.Equal(t, Info, logger.GetLevel())
+
+		// Set it to trace level to log trace msg
+		buf.Reset()
+		lvar.Set(SlogLevelTrace)
+		logger.Trace("trace msg")
+		assert.Equal(t, "level=DEBUG-4 msg=\"trace msg\"\n", buf.String())
+		assert.Equal(t, Trace, logger.GetLevel())
+	})
+	t.Run("name related", func(t *testing.T) {
+		var buf bytes.Buffer
+		logger := newSimple(slog.LevelInfo, &buf)
+		n1Logger := logger.Named("n1")
+		n2Logger := n1Logger.Named("n2")
+
+		assert.Equal(t, "", logger.Name())
+		assert.Equal(t, "n1", n1Logger.Name())
+		assert.Equal(t, "n1.n2", n2Logger.Name())
+
+		logger.Info("msg", "age", 1)
+		assert.Equal(t, "level=INFO msg=msg age=1\n", buf.String())
+
+		buf.Reset()
+		n1Logger.Info("msg", "age", 1)
+		assert.Equal(t, "level=INFO msg=msg n1.age=1\n", buf.String())
+
+		buf.Reset()
+		n2Logger.Info("msg", "age", 1)
+		assert.Equal(t, "level=INFO msg=msg n1.n2.age=1\n", buf.String())
+
+		n2Logger = n2Logger.ResetNamed("")
+		buf.Reset()
+		n2Logger.Info("msg", "age", 1)
+		assert.Equal(t, "level=INFO msg=msg age=1\n", buf.String())
+		assert.Equal(t, "", n2Logger.Name())
+
+		n1Logger = n1Logger.ResetNamed("n11")
+		buf.Reset()
+		n1Logger.Info("msg", "age", 1)
+		assert.Equal(t, "level=INFO msg=msg n11.age=1\n", buf.String())
+		assert.Equal(t, "n11", n1Logger.Name())
+
+		logger = logger.ResetNamed("n0")
+		buf.Reset()
+		logger.Info("msg", "age", 1)
+		assert.Equal(t, "level=INFO msg=msg n0.age=1\n", buf.String())
+		assert.Equal(t, "n0", logger.Name())
+	})
+	t.Run("with args", func(t *testing.T) {
+		var buf bytes.Buffer
+		logger := newSimple(slog.LevelInfo, &buf)
+		logger = logger.With("foo", "bar")
+		assert.Equal(t, []interface{}{"foo", "bar"}, logger.ImpliedArgs())
+		logger.Info("msg")
+		assert.Equal(t, "level=INFO msg=msg foo=bar\n", buf.String())
+	})
+	t.Run("standard logger", func(t *testing.T) {
+		var buf bytes.Buffer
+		logger := newSimple(SlogLevelTrace, &buf)
+
+		stdlogger := logger.StandardLogger(&StandardLoggerOptions{InferLevels: true})
+		stdwriter := logger.StandardWriter(&StandardLoggerOptions{InferLevels: true})
+
+		cases := []struct {
+			input  string
+			expect string
+		}{
+			{
+				input:  "[TRACE] msg",
+				expect: "level=DEBUG-4 msg=msg\n",
+			},
+			{
+				input:  "[DEBUG] msg",
+				expect: "level=DEBUG msg=msg\n",
+			},
+			{
+				input:  "[INFO] msg",
+				expect: "level=INFO msg=msg\n",
+			},
+			{
+				input:  "[WARN] msg",
+				expect: "level=WARN msg=msg\n",
+			},
+			{
+				input:  "[ERROR] msg",
+				expect: "level=ERROR msg=msg\n",
+			},
+		}
+
+		for _, cc := range cases {
+			buf.Reset()
+			stdlogger.Println(cc.input)
+			assert.Equal(t, cc.expect, buf.String())
+
+			buf.Reset()
+			stdwriter.Write([]byte(cc.input))
+			assert.Equal(t, cc.expect, buf.String())
+		}
+	})
+}


### PR DESCRIPTION
`slog.Logger`, similar to `log.Logger`, is a Go 1st class logger type in the standard library. The `slog.Logger` is also [used as an important interface for the OpenTelemetry logging package for Go](https://github.com/open-telemetry/opentelemetry-go-contrib/tree/main/bridges/otelslog). The current module has support for `log.Logger`, so it would be intuitive to have the `slog.Logger` supported as well.

This PR introduces a new function `FromStandardSLogger` for wrapping a `slog.Logger` into a `hclog.Logger`, similar to the `FromStandardLogger`. The difference is the interface is a bit different, in that a `LoggerOptions` is not needed, as those tunnable part are dominated by the `slog.Logger` itself. Meanwhile, it has an optional parameter `lvar`, which is a `slog.LevelVar`. When this is not `nil`, it is used for supporting the `SetLevel` method of the returned `hclog.Logger` (as there is no way to retrieve the `slog.LevelVar` from a `slog.Logger`.

There are also two additional consts introduced:

- `SlogLevelTrace`: For supporting the `hclog.Trace` level
- `SlogLevelOff`: For supporting the `hclog.Off` level

The args related feature is implemented natively by the slog [attributes](https://pkg.go.dev/golang.org/x/exp/slog#hdr-Attrs_and_Values).

The name related feature is implemented natively by the slog [groups](https://pkg.go.dev/golang.org/x/exp/slog#hdr-Groups).