### PR TITLE
v2 suggestions

### DIFF
--- a/exclude.go
+++ b/exclude.go
@@ -10,7 +10,7 @@ import (
 
 // ExcludeByMessage provides a simple way to build a list of log messages that
 // can be queried and matched. This is meant to be used with the Exclude
-// option on Options to suppress log messages. This does not hold any mutexs
+// option on Options to suppress log messages. This does not hold any mutexes
 // within itself, so normal usage would be to Add entries at setup and none after
 // Exclude is going to be called. Exclude is called with a mutex held within
 // the Logger, so that doesn't need to use a mutex. Example usage:
@@ -32,8 +32,8 @@ func (f *ExcludeByMessage) Add(msg string) {
 	f.messages[msg] = struct{}{}
 }
 
-// Return true if the given message should be included
-func (f *ExcludeByMessage) Exclude(level Level, msg string, args ...interface{}) bool {
+// Exclude returns true if the given message should be included.
+func (f *ExcludeByMessage) Exclude(_ Level, msg string, _ ...interface{}) bool {
 	_, ok := f.messages[msg]
 	return ok
 }
@@ -41,8 +41,8 @@ func (f *ExcludeByMessage) Exclude(level Level, msg string, args ...interface{})
 // ExcludeByPrefix is a simple type to match a message string that has a common prefix.
 type ExcludeByPrefix string
 
-// Matches an message that starts with the prefix.
-func (p ExcludeByPrefix) Exclude(level Level, msg string, args ...interface{}) bool {
+// Exclude matches an message that starts with the prefix.
+func (p ExcludeByPrefix) Exclude(_ Level, msg string, _ ...interface{}) bool {
 	return strings.HasPrefix(msg, string(p))
 }
 
@@ -52,17 +52,17 @@ type ExcludeByRegexp struct {
 	Regexp *regexp.Regexp
 }
 
-// Exclude the log message if the message string matches the regexp
+// Exclude the log message if the message string matches the regexp.
 func (e ExcludeByRegexp) Exclude(level Level, msg string, args ...interface{}) bool {
 	return e.Regexp.MatchString(msg)
 }
 
-// ExcludeFuncs is a slice of functions that will called to see if a log entry
+// ExcludeFuncs is a slice of functions that will be called to see if a log entry
 // should be filtered or not. It stops calling functions once at least one returns
 // true.
 type ExcludeFuncs []func(level Level, msg string, args ...interface{}) bool
 
-// Calls each function until one of them returns true
+// Exclude calls each function until one of them returns true
 func (ff ExcludeFuncs) Exclude(level Level, msg string, args ...interface{}) bool {
 	for _, f := range ff {
 		if f(level, msg, args...) {

--- a/interceptlogger.go
+++ b/interceptlogger.go
@@ -42,7 +42,7 @@ func (i *interceptLogger) Log(level Level, msg string, args ...interface{}) {
 	i.log(level, msg, args...)
 }
 
-// log is used to make the caller stack frame lookup consistent. If Warn,Info,etc
+// log is used to make the caller stack frame lookup consistent. If Warn, Info, etc.
 // all called Log then direct calls to Log would have a different stack frame
 // depth. By having all the methods call the same helper we ensure the stack
 // frame depth is the same.
@@ -59,27 +59,27 @@ func (i *interceptLogger) log(level Level, msg string, args ...interface{}) {
 	}
 }
 
-// Emit the message and args at TRACE level to log and sinks
+// Trace emits a message and key/value pairs at the TRACE level to log and sinks.
 func (i *interceptLogger) Trace(msg string, args ...interface{}) {
 	i.log(Trace, msg, args...)
 }
 
-// Emit the message and args at DEBUG level to log and sinks
+// Debug emits a message and key/value pairs at the DEBUG level to log and sinks.
 func (i *interceptLogger) Debug(msg string, args ...interface{}) {
 	i.log(Debug, msg, args...)
 }
 
-// Emit the message and args at INFO level to log and sinks
+// Info emits a message and key/value pairs at the INFO level to log and sinks.
 func (i *interceptLogger) Info(msg string, args ...interface{}) {
 	i.log(Info, msg, args...)
 }
 
-// Emit the message and args at WARN level to log and sinks
+// Warn emits a message and key/value pairs at the WARN level to log and sinks.
 func (i *interceptLogger) Warn(msg string, args ...interface{}) {
 	i.log(Warn, msg, args...)
 }
 
-// Emit the message and args at ERROR level to log and sinks
+// Error emits a message and key/value pairs at the ERROR level to log and sinks.
 func (i *interceptLogger) Error(msg string, args ...interface{}) {
 	i.log(Error, msg, args...)
 }
@@ -94,14 +94,14 @@ func (i *interceptLogger) retrieveImplied(args ...interface{}) []interface{} {
 	return cp
 }
 
-// Create a new sub-Logger that a name descending from the current name.
+// Named creates a new sub-Logger with a name descending from the current name.
 // This is used to create a subsystem specific Logger.
 // Registered sinks will subscribe to these messages as well.
 func (i *interceptLogger) Named(name string) LogImpl {
 	return i.NamedIntercept(name)
 }
 
-// Create a new sub-Logger with an explicit name. This ignores the current
+// ResetNamed creates a new sub-Logger with an explicit name. This ignores the current
 // name. This is used to create a standalone logger that doesn't fall
 // within the normal hierarchy. Registered sinks will subscribe
 // to these messages as well.
@@ -109,8 +109,8 @@ func (i *interceptLogger) ResetNamed(name string) LogImpl {
 	return i.ResetNamedIntercept(name)
 }
 
-// Create a new sub-Logger that a name decending from the current name.
-// This is used to create a subsystem specific Logger.
+// NamedIntercept creates a new sub-Logger with a name descending from the current name.
+// This is used to create a subsystem specific LogImpl.
 // Registered sinks will subscribe to these messages as well.
 func (i *interceptLogger) NamedIntercept(name string) InterceptLogger {
 	var sub interceptLogger
@@ -120,7 +120,7 @@ func (i *interceptLogger) NamedIntercept(name string) InterceptLogger {
 	return &sub
 }
 
-// Create a new sub-Logger with an explicit name. This ignores the current
+// ResetNamedIntercept creates a new sub-Logger with an explicit name. This ignores the current
 // name. This is used to create a standalone logger that doesn't fall
 // within the normal hierarchy. Registered sinks will subscribe
 // to these messages as well.
@@ -132,9 +132,8 @@ func (i *interceptLogger) ResetNamedIntercept(name string) InterceptLogger {
 	return &sub
 }
 
-// Return a sub-Logger for which every emitted log message will contain
-// the given key/value pairs. This is used to create a context specific
-// Logger.
+// With returns a sub-Logger for which every emitted log message will contain
+// the given key/value pairs. This is used to create a context specific LogImpl.
 func (i *interceptLogger) With(args ...interface{}) LogImpl {
 	var sub interceptLogger
 
@@ -177,10 +176,12 @@ func (i *interceptLogger) StandardLogger(opts *StandardLoggerOptions) *log.Logge
 	return log.New(i.StandardWriter(opts), "", 0)
 }
 
+// Deprecated: use LogImpl.StandardWriter
 func (i *interceptLogger) StandardWriterIntercept(opts *StandardLoggerOptions) io.Writer {
 	return i.StandardWriter(opts)
 }
 
+// StandardWriter returns a value that conforms to io.Writer, which can be passed into log.SetOutput().
 func (i *interceptLogger) StandardWriter(opts *StandardLoggerOptions) io.Writer {
 	return &stdlogAdapter{
 		log:                      i,
@@ -190,6 +191,8 @@ func (i *interceptLogger) StandardWriter(opts *StandardLoggerOptions) io.Writer 
 	}
 }
 
+// ResetOutput swaps the current output writer with the one given in the
+// opts. Color options given in opts will be used for the new output.
 func (i *interceptLogger) ResetOutput(opts *LoggerOptions) error {
 	if or, ok := i.LogImpl.(OutputResettable); ok {
 		return or.ResetOutput(opts)
@@ -198,6 +201,9 @@ func (i *interceptLogger) ResetOutput(opts *LoggerOptions) error {
 	}
 }
 
+// ResetOutputWithFlush swaps the current output writer with the one given
+// in the opts, first calling Flush on the given Flushable. Color options
+// given in opts will be used for the new output.
 func (i *interceptLogger) ResetOutputWithFlush(opts *LoggerOptions, flushable Flushable) error {
 	if or, ok := i.LogImpl.(OutputResettable); ok {
 		return or.ResetOutputWithFlush(opts, flushable)

--- a/intlogger.go
+++ b/intlogger.go
@@ -226,7 +226,9 @@ const offsetIntLogger = 4
 // Log a message and a set of key/value pairs if the given level is at
 // or more severe that the threshold configured in the Logger.
 func (l *intLogger) log(name string, level Level, msg string, args ...interface{}) {
-	if level < l.Level() {
+	// Return early if the requested level is set to 'off', or is a higher fidelity
+	// than the logger is configured for.
+	if level == Off || level < l.Level() {
 		return
 	}
 

--- a/intlogger.go
+++ b/intlogger.go
@@ -226,7 +226,7 @@ const offsetIntLogger = 4
 // Log a message and a set of key/value pairs if the given level is at
 // or more severe that the threshold configured in the Logger.
 func (l *intLogger) log(name string, level Level, msg string, args ...interface{}) {
-	if level < l.GetLevel() {
+	if level < l.Level() {
 		return
 	}
 
@@ -680,7 +680,7 @@ func (l *intLogger) logJSON(t time.Time, name string, level Level, msg string, a
 	}
 }
 
-func (l intLogger) jsonMapEntry(t time.Time, name string, level Level, msg string) map[string]interface{} {
+func (l *intLogger) jsonMapEntry(t time.Time, name string, level Level, msg string) map[string]interface{} {
 	vals := map[string]interface{}{
 		"@message": msg,
 	}
@@ -755,27 +755,27 @@ func (l *intLogger) Error(msg string, args ...interface{}) {
 
 // Indicate that the logger would emit TRACE level logs
 func (l *intLogger) IsTrace() bool {
-	return l.GetLevel() == Trace
+	return l.Level() == Trace
 }
 
 // Indicate that the logger would emit DEBUG level logs
 func (l *intLogger) IsDebug() bool {
-	return l.GetLevel() <= Debug
+	return l.Level() <= Debug
 }
 
 // Indicate that the logger would emit INFO level logs
 func (l *intLogger) IsInfo() bool {
-	return l.GetLevel() <= Info
+	return l.Level() <= Info
 }
 
 // Indicate that the logger would emit WARN level logs
 func (l *intLogger) IsWarn() bool {
-	return l.GetLevel() <= Warn
+	return l.Level() <= Warn
 }
 
 // Indicate that the logger would emit ERROR level logs
 func (l *intLogger) IsError() bool {
-	return l.GetLevel() <= Error
+	return l.Level() <= Error
 }
 
 const MissingKey = "EXTRA_VALUE_AT_END"
@@ -925,7 +925,7 @@ func (l *intLogger) searchLevelPtr() *int32 {
 }
 
 // Returns the current level
-func (l *intLogger) GetLevel() Level {
+func (l *intLogger) Level() Level {
 	// We perform the loads immediately to keep the CPU pipeline busy, which
 	// effectively makes the second load cost nothing. Once loaded into registers
 	// the comparison returns the already loaded value. The comparison is almost
@@ -950,8 +950,8 @@ func (l *intLogger) GetLevel() Level {
 	return Level(atomic.LoadInt32(ptr))
 }
 
-// Create a *log.Logger that will send it's data through this Logger. This
-// allows packages that expect to be using the standard library log to actually
+// StandardLogger creates a *log.Logger that will send its data through this Logger.
+// This allows packages that expect to be using the standard library log to actually
 // use this logger.
 func (l *intLogger) StandardLogger(opts *StandardLoggerOptions) *log.Logger {
 	if opts == nil {

--- a/logger.go
+++ b/logger.go
@@ -59,19 +59,19 @@ func Fmt(str string, args ...interface{}) Format {
 	return append(Format{str}, args...)
 }
 
-// A simple shortcut to format numbers in hex when displayed with the normal
-// text output. For example: L.Info("header value", Hex(17))
+// Hex provides a simple shortcut to format numbers in hex when displayed with the normal
+// text output. For example: L.Info("header value", Hex(17)).
 type Hex int
 
-// A simple shortcut to format numbers in octal when displayed with the normal
-// text output. For example: L.Info("perms", Octal(17))
+// Octal provides a simple shortcut to format numbers in octal when displayed with the normal
+// text output. For example: L.Info("perms", Octal(17)).
 type Octal int
 
-// A simple shortcut to format numbers in binary when displayed with the normal
-// text output. For example: L.Info("bits", Binary(17))
+// Binary provides a simple shortcut to format numbers in binary when displayed with the normal
+// text output. For example: L.Info("bits", Binary(17)).
 type Binary int
 
-// A simple shortcut to format strings with Go quoting. Control and
+// Quote provides a simple shortcut to format strings with Go quoting. Control and
 // non-printable characters will be escaped with their backslash equivalents in
 // output. Intended for untrusted or multiline strings which should be logged
 // as concisely as possible.
@@ -123,6 +123,7 @@ func LevelFromString(levelStr string) Level {
 	}
 }
 
+// String returns a lowercase string representation of a Level.
 func (l Level) String() string {
 	switch l {
 	case Trace:
@@ -145,78 +146,83 @@ func (l Level) String() string {
 }
 
 // LogImpl describes the interface that must be implemented by all loggers.
+// TODO: Suggested names: BaseLogger, CoreLogger, RootLogger. Impl just doesn't feel right.
 type LogImpl interface {
-	// Args are alternating key, val pairs
-	// keys must be strings
-	// vals can be any type, but display is implementation specific
-	// Emit a message and key/value pairs at a provided log level
+	// Log emits a message and key/value pairs at a provided log level.
+	// Args are alternating key, val pairs.
+	// Keys must be strings.
+	// Vals can be any type, but display is implementation specific.
 	Log(level Level, msg string, args ...interface{})
 
 	LogRecord(Record)
 
-	// Emit a message and key/value pairs at the TRACE level
+	// Trace emits a message and key/value pairs at the TRACE level.
 	Trace(msg string, args ...interface{})
 
-	// Emit a message and key/value pairs at the DEBUG level
+	// Debug emits a message and key/value pairs at the DEBUG level.
 	Debug(msg string, args ...interface{})
 
-	// Emit a message and key/value pairs at the INFO level
+	// Info emits a message and key/value pairs at the INFO level.
 	Info(msg string, args ...interface{})
 
-	// Emit a message and key/value pairs at the WARN level
+	// Warn emits a message and key/value pairs at the WARN level.
 	Warn(msg string, args ...interface{})
 
-	// Emit a message and key/value pairs at the ERROR level
+	// Error emits a message and key/value pairs at the ERROR level.
 	Error(msg string, args ...interface{})
 
-	// Indicate if TRACE logs would be emitted. This and the other Is* guards
-	// are used to elide expensive logging code based on the current level.
+	// IsTrace indicates if TRACE logs would be emitted.
+	// This and the other Is* guards are used to elide expensive logging code based on the current level.
 	IsTrace() bool
 
-	// Indicate if DEBUG logs would be emitted. This and the other Is* guards
+	// IsDebug indicates if DEBUG logs would be emitted. This and the other Is* guards.
+	// This and the other Is* guards are used to elide expensive logging code based on the current level.
 	IsDebug() bool
 
-	// Indicate if INFO logs would be emitted. This and the other Is* guards
+	// IsInfo indicates if INFO logs would be emitted. This and the other Is* guards.
+	// This and the other Is* guards are used to elide expensive logging code based on the current level.
 	IsInfo() bool
 
-	// Indicate if WARN logs would be emitted. This and the other Is* guards
+	// IsWarn indicates if WARN logs would be emitted. This and the other Is* guards.
+	// This and the other Is* guards are used to elide expensive logging code based on the current level.
 	IsWarn() bool
 
-	// Indicate if ERROR logs would be emitted. This and the other Is* guards
+	// IsError indicates if ERROR logs would be emitted. This and the other Is* guards.
+	// This and the other Is* guards are used to elide expensive logging code based on the current level.
 	IsError() bool
 
-	// ImpliedArgs returns With key/value pairs
+	// ImpliedArgs returns With key/value pairs.
 	ImpliedArgs() []interface{}
 
-	// Creates a sublogger that will always have the given key/value pairs
+	// With creates a sublogger that will always have the given key/value pairs.
 	With(args ...interface{}) LogImpl
 
-	// Returns the Name of the logger
+	// Name returns the Name of the logger
 	Name() string
 
-	// Create a logger that will prepend the name string on the front of all messages.
+	// Named creates a logger that will prepend the name string on the front of all messages.
 	// If the logger already has a name, the new value will be appended to the current
-	// name. That way, a major subsystem can use this to decorate all it's own logs
+	// name. That way, a major subsystem can use this to decorate all its own logs
 	// without losing context.
 	Named(name string) LogImpl
 
-	// Create a logger that will prepend the name string on the front of all messages.
+	// ResetNamed creates a logger that will prepend the name string on the front of all messages.
 	// This sets the name of the logger to the value directly, unlike Named which honor
 	// the current name as well.
 	ResetNamed(name string) LogImpl
 
-	// Updates the level. This should affect all related loggers as well,
+	// SetLevel updates the level. This should affect all related loggers as well,
 	// unless they were created with IndependentLevels. If an
 	// implementation cannot update the level on the fly, it should no-op.
 	SetLevel(level Level)
 
-	// Returns the current level
-	GetLevel() Level
+	// Level returns the current level.
+	Level() Level
 
-	// Return a value that conforms to the stdlib log.Logger interface
+	// StandardLogger returns a value that conforms to the stdlib log.Logger interface.
 	StandardLogger(opts *StandardLoggerOptions) *log.Logger
 
-	// Return a value that conforms to io.Writer, which can be passed into log.SetOutput()
+	// StandardWriter returns a value that conforms to io.Writer, which can be passed into log.SetOutput().
 	StandardWriter(opts *StandardLoggerOptions) io.Writer
 }
 
@@ -249,13 +255,13 @@ type TimeFunction = func() time.Time
 
 // LoggerOptions can be used to configure a new logger.
 type LoggerOptions struct {
-	// Name of the subsystem to prefix logs with
+	// Name of the subsystem to prefix logs with.
 	Name string
 
-	// The threshold for the logger. Anything less severe is suppressed
+	// The threshold for the logger. Anything less severe is suppressed.
 	Level Level
 
-	// Where to write the logs to. Defaults to os.Stderr if nil
+	// Where to write the logs to. Defaults to os.Stderr if nil.
 	Output io.Writer
 
 	// An optional Locker in case Output is shared. This can be a sync.Mutex or
@@ -266,20 +272,20 @@ type LoggerOptions struct {
 	// Control if the output should be in JSON.
 	JSONFormat bool
 
-	// Include file and line information in each log line
+	// Include file and line information in each log line.
 	IncludeLocation bool
 
 	// AdditionalLocationOffset is the number of additional stack levels to skip
-	// when finding the file and line information for the log line
+	// when finding the file and line information for the log line.
 	AdditionalLocationOffset int
 
-	// The time format to use instead of the default
+	// The time format to use instead of the default.
 	TimeFormat string
 
-	// A function which is called to get the time object that is formatted using `TimeFormat`
+	// A function which is called to get the time object that is formatted using `TimeFormat`.
 	TimeFn TimeFunction
 
-	// Control whether or not to display the time at all. This is required
+	// Control whether to display the time at all. This is required
 	// because setting TimeFormat to empty assumes the default format.
 	DisableTime bool
 
@@ -297,7 +303,7 @@ type LoggerOptions struct {
 	// A function which is called with the log information and if it returns true the value
 	// should not be logged.
 	// This is useful when interacting with a system that you wish to suppress the log
-	// message for (because it's too noisy, etc)
+	// message for (because it's too noisy, etc.).
 	Exclude func(level Level, msg string, args ...interface{}) bool
 
 	// IndependentLevels causes subloggers to be created with an independent
@@ -312,16 +318,16 @@ type LoggerOptions struct {
 	// a.SetLevel(Error)
 	// b := a.Named("b")
 	// c := a.Named("c")
-	// b.GetLevel() => Error
-	// c.GetLevel() => Error
+	// b.Level() => Error
+	// c.Level() => Error
 	// b.SetLevel(Info)
-	// a.GetLevel() => Error
-	// b.GetLevel() => Info
-	// c.GetLevel() => Error
+	// a.Level() => Error
+	// b.Level() => Info
+	// c.Level() => Error
 	// a.SetLevel(Warn)
-	// a.GetLevel() => Warn
-	// b.GetLevel() => Warn
-	// c.GetLevel() => Warn
+	// a.Level() => Warn
+	// b.Level() => Warn
+	// c.Level() => Warn
 	SyncParentLevel bool
 
 	// SubloggerHook registers a function that is called when a sublogger via
@@ -338,7 +344,7 @@ type LoggerOptions struct {
 // to a different output while keeping the root logger
 // at a higher one.
 type InterceptLogger interface {
-	// Logger is the root logger for an InterceptLogger
+	// LogImpl is the root logger for an InterceptLogger
 	LogImpl
 
 	// RegisterSink adds a SinkAdapter to the InterceptLogger
@@ -347,21 +353,21 @@ type InterceptLogger interface {
 	// DeregisterSink removes a SinkAdapter from the InterceptLogger
 	DeregisterSink(sink SinkAdapter)
 
-	// Create a interceptlogger that will prepend the name string on the front of all messages.
+	// NamedIntercept creates an InterceptLogger that will prepend the name string on the front of all messages.
 	// If the logger already has a name, the new value will be appended to the current
-	// name. That way, a major subsystem can use this to decorate all it's own logs
+	// name. That way, a major subsystem can use this to decorate all its own logs
 	// without losing context.
 	NamedIntercept(name string) InterceptLogger
 
-	// Create a interceptlogger that will prepend the name string on the front of all messages.
-	// This sets the name of the logger to the value directly, unlike Named which honor
+	// ResetNamedIntercept returns an InterceptLogger that will prepend the name string on the front of all messages.
+	// This sets the name of the logger to the value directly, unlike LogImpl.Named which honor
 	// the current name as well.
 	ResetNamedIntercept(name string) InterceptLogger
 
-	// Deprecated: use StandardLogger
+	// Deprecated: use LogImpl.StandardLogger
 	StandardLoggerIntercept(opts *StandardLoggerOptions) *log.Logger
 
-	// Deprecated: use StandardWriter
+	// Deprecated: use LogImpl.StandardWriter
 	StandardWriterIntercept(opts *StandardLoggerOptions) io.Writer
 }
 

--- a/logger_test.go
+++ b/logger_test.go
@@ -651,19 +651,19 @@ func TestLogger(t *testing.T) {
 
 		b.SetLevel(Info)
 
-		assert.Equal(t, Error, a.GetLevel())
+		assert.Equal(t, Error, a.Level())
 
 		a.SetLevel(Error)
 
-		assert.Equal(t, Error, b.GetLevel())
+		assert.Equal(t, Error, b.Level())
 
-		assert.Equal(t, Error, c.GetLevel())
+		assert.Equal(t, Error, c.Level())
 
 		// Make sure that setting a sibling logger doesn't confuse
 		// when b had previously had it's own level.
 		c.SetLevel(Info)
 
-		assert.Equal(t, Error, b.GetLevel())
+		assert.Equal(t, Error, b.Level())
 	})
 
 	t.Run("level sync example 1", func(t *testing.T) {
@@ -682,25 +682,25 @@ func TestLogger(t *testing.T) {
 		c := a.Named("c")
 
 		b.SetLevel(Warn)
-		s.Equal(Info, a.GetLevel())
-		s.Equal(Warn, b.GetLevel())
-		s.Equal(Info, c.GetLevel())
+		s.Equal(Info, a.Level())
+		s.Equal(Warn, b.Level())
+		s.Equal(Info, c.Level())
 
 		c.SetLevel(Error)
-		s.Equal(Info, a.GetLevel())
-		s.Equal(Warn, b.GetLevel())
-		s.Equal(Error, c.GetLevel())
+		s.Equal(Info, a.Level())
+		s.Equal(Warn, b.Level())
+		s.Equal(Error, c.Level())
 
 		a.SetLevel(Warn)
-		s.Equal(Warn, a.GetLevel())
-		s.Equal(Warn, b.GetLevel())
-		s.Equal(Warn, c.GetLevel())
+		s.Equal(Warn, a.Level())
+		s.Equal(Warn, b.Level())
+		s.Equal(Warn, c.Level())
 
 		logger.SetLevel(Trace)
-		s.Equal(Trace, logger.GetLevel())
-		s.Equal(Trace, a.GetLevel())
-		s.Equal(Trace, b.GetLevel())
-		s.Equal(Trace, c.GetLevel())
+		s.Equal(Trace, logger.Level())
+		s.Equal(Trace, a.Level())
+		s.Equal(Trace, b.Level())
+		s.Equal(Trace, c.Level())
 	})
 
 	t.Run("level sync example 2", func(t *testing.T) {
@@ -718,24 +718,24 @@ func TestLogger(t *testing.T) {
 		a.SetLevel(Error)
 		b := a.Named("b")
 		c := a.Named("c")
-		s.Equal(Error, b.GetLevel())
-		s.Equal(Error, c.GetLevel())
+		s.Equal(Error, b.Level())
+		s.Equal(Error, c.Level())
 
 		b.SetLevel(Info)
-		s.Equal(Error, a.GetLevel())
-		s.Equal(Info, b.GetLevel())
-		s.Equal(Error, c.GetLevel())
+		s.Equal(Error, a.Level())
+		s.Equal(Info, b.Level())
+		s.Equal(Error, c.Level())
 
 		a.SetLevel(Warn)
-		s.Equal(Warn, a.GetLevel())
-		s.Equal(Warn, b.GetLevel())
-		s.Equal(Warn, c.GetLevel())
+		s.Equal(Warn, a.Level())
+		s.Equal(Warn, b.Level())
+		s.Equal(Warn, c.Level())
 
 		logger.SetLevel(Trace)
-		s.Equal(Trace, logger.GetLevel())
-		s.Equal(Trace, a.GetLevel())
-		s.Equal(Trace, b.GetLevel())
-		s.Equal(Trace, c.GetLevel())
+		s.Equal(Trace, logger.Level())
+		s.Equal(Trace, a.Level())
+		s.Equal(Trace, b.Level())
+		s.Equal(Trace, c.Level())
 	})
 	t.Run("level sync example 3", func(t *testing.T) {
 		var buf bytes.Buffer
@@ -752,24 +752,24 @@ func TestLogger(t *testing.T) {
 		b := a.Named("b")
 
 		a.SetLevel(Trace)
-		s.Equal(Trace, a.GetLevel())
-		s.Equal(Trace, b.GetLevel())
+		s.Equal(Trace, a.Level())
+		s.Equal(Trace, b.Level())
 
 		b.SetLevel(Warn)
-		s.Equal(Trace, a.GetLevel())
-		s.Equal(Warn, b.GetLevel())
+		s.Equal(Trace, a.Level())
+		s.Equal(Warn, b.Level())
 
 		c := a.Named("c")
 
 		c.SetLevel(Error)
-		s.Equal(Trace, a.GetLevel())
-		s.Equal(Warn, b.GetLevel())
-		s.Equal(Error, c.GetLevel())
+		s.Equal(Trace, a.Level())
+		s.Equal(Warn, b.Level())
+		s.Equal(Error, c.Level())
 
 		a.SetLevel(Warn)
-		s.Equal(Warn, a.GetLevel())
-		s.Equal(Warn, b.GetLevel())
-		s.Equal(Warn, c.GetLevel())
+		s.Equal(Warn, a.Level())
+		s.Equal(Warn, b.Level())
+		s.Equal(Warn, c.Level())
 	})
 }
 

--- a/nulllogger.go
+++ b/nulllogger.go
@@ -5,7 +5,6 @@ package hclog
 
 import (
 	"io"
-	"io/ioutil"
 	"log"
 )
 
@@ -18,18 +17,19 @@ func NewNullLogger() LogImpl {
 
 type nullLogger struct{}
 
-func (l *nullLogger) Log(level Level, msg string, args ...interface{}) {}
-func (l *nullLogger) LogRecord(r Record)                               {}
+func (l *nullLogger) Log(_ Level, _ string, _ ...interface{}) {}
 
-func (l *nullLogger) Trace(msg string, args ...interface{}) {}
+func (l *nullLogger) LogRecord(_ Record) {}
 
-func (l *nullLogger) Debug(msg string, args ...interface{}) {}
+func (l *nullLogger) Trace(_ string, _ ...interface{}) {}
 
-func (l *nullLogger) Info(msg string, args ...interface{}) {}
+func (l *nullLogger) Debug(_ string, _ ...interface{}) {}
 
-func (l *nullLogger) Warn(msg string, args ...interface{}) {}
+func (l *nullLogger) Info(_ string, _ ...interface{}) {}
 
-func (l *nullLogger) Error(msg string, args ...interface{}) {}
+func (l *nullLogger) Warn(_ string, _ ...interface{}) {}
+
+func (l *nullLogger) Error(_ string, _ ...interface{}) {}
 
 func (l *nullLogger) IsTrace() bool { return false }
 
@@ -43,22 +43,22 @@ func (l *nullLogger) IsError() bool { return false }
 
 func (l *nullLogger) ImpliedArgs() []interface{} { return []interface{}{} }
 
-func (l *nullLogger) With(args ...interface{}) LogImpl { return l }
+func (l *nullLogger) With(_ ...interface{}) LogImpl { return l }
 
 func (l *nullLogger) Name() string { return "" }
 
-func (l *nullLogger) Named(name string) LogImpl { return l }
+func (l *nullLogger) Named(_ string) LogImpl { return l }
 
-func (l *nullLogger) ResetNamed(name string) LogImpl { return l }
+func (l *nullLogger) ResetNamed(_ string) LogImpl { return l }
 
-func (l *nullLogger) SetLevel(level Level) {}
+func (l *nullLogger) SetLevel(_ Level) {}
 
-func (l *nullLogger) GetLevel() Level { return NoLevel }
+func (l *nullLogger) Level() Level { return NoLevel }
 
 func (l *nullLogger) StandardLogger(opts *StandardLoggerOptions) *log.Logger {
 	return log.New(l.StandardWriter(opts), "", log.LstdFlags)
 }
 
-func (l *nullLogger) StandardWriter(opts *StandardLoggerOptions) io.Writer {
-	return ioutil.Discard
+func (l *nullLogger) StandardWriter(_ *StandardLoggerOptions) io.Writer {
+	return io.Discard
 }

--- a/stdlog.go
+++ b/stdlog.go
@@ -14,7 +14,7 @@ import (
 // beginning of inputs.
 var logTimestampRegexp = regexp.MustCompile(`^[\d\s\:\/\.\+-TZ]*`)
 
-// Provides a io.Writer to shim the data out of *log.Logger
+// stdlogAdapter provides an io.Writer to shim the data out of *log.Logger
 // and back into our Logger. This is basically the only way to
 // build upon *log.Logger.
 type stdlogAdapter struct {
@@ -24,7 +24,7 @@ type stdlogAdapter struct {
 	forceLevel               Level
 }
 
-// Take the data, infer the levels if configured, and send it through
+// Write takes the data, infer the levels if configured, and send it through
 // a regular Logger.
 func (s *stdlogAdapter) Write(data []byte) (int, error) {
 	str := string(bytes.TrimRight(data, " \t\n"))
@@ -67,7 +67,7 @@ func (s *stdlogAdapter) dispatch(str string, level Level) {
 	}
 }
 
-// Detect, based on conventions, what log level this is.
+// pickLevel detects, based on conventions, what log level this is.
 func (s *stdlogAdapter) pickLevel(str string) (Level, string) {
 	switch {
 	case strings.HasPrefix(str, "[DEBUG]"):
@@ -101,7 +101,7 @@ func (l *logWriter) Write(b []byte) (int, error) {
 	return len(b), nil
 }
 
-// Takes a standard library logger and returns a Logger that will write to it
+// FromStandardLogger takes a standard library logger and returns a Logger that will write to it.
 func FromStandardLogger(l *log.Logger, opts *LoggerOptions) Logger {
 	var dl LoggerOptions = *opts
 

--- a/value.go
+++ b/value.go
@@ -9,7 +9,8 @@ type Logger struct {
 }
 
 func (v *Logger) log(level Level, msg string, args ...interface{}) {
-	// Return early if the level is set to 'off' or is a lower level than the logger is configured for.
+	// Return early if the requested level is set to 'off', or is a higher fidelity
+	// than the logger is configured for.
 	if level == Off || level < v.impl.Level() {
 		return
 	}

--- a/value.go
+++ b/value.go
@@ -9,7 +9,8 @@ type Logger struct {
 }
 
 func (v *Logger) log(level Level, msg string, args ...interface{}) {
-	if level < v.impl.GetLevel() {
+	// Return early if the level is set to 'off' or is a lower level than the logger is configured for.
+	if level == Off || level < v.impl.Level() {
 		return
 	}
 
@@ -30,84 +31,103 @@ func (v *Logger) log(level Level, msg string, args ...interface{}) {
 	v.impl.LogRecord(r)
 }
 
-// Emit the message and args at the given level
+// Log emits a message and key/value pairs at a provided log level.
+// Args are alternating key, val pairs.
+// Keys must be strings.
+// Vals can be any type, but display is implementation specific.
 func (v *Logger) Log(level Level, msg string, args ...interface{}) {
 	v.log(level, msg, args...)
 }
 
-// Emit the message and args at TRACE level
+// Trace emits a message and key/value pairs at the TRACE level.
 func (v *Logger) Trace(msg string, args ...interface{}) {
 	v.log(Trace, msg, args...)
 }
 
-// Emit the message and args at DEBUG level
+// Debug emits a message and key/value pairs at the DEBUG level.
 func (v *Logger) Debug(msg string, args ...interface{}) {
 	v.log(Debug, msg, args...)
 }
 
-// Emit the message and args at INFO level
+// Info emits a message and key/value pairs at the INFO level.
 func (v *Logger) Info(msg string, args ...interface{}) {
 	v.log(Info, msg, args...)
 }
 
-// Emit the message and args at WARN level
+// Warn emits a message and key/value pairs at the WARN level.
 func (v *Logger) Warn(msg string, args ...interface{}) {
 	v.log(Warn, msg, args...)
 }
 
-// Emit the message and args at ERROR level
-func (v Logger) Error(msg string, args ...interface{}) {
+// Error emits a message and key/value pairs at the ERROR level.
+func (v *Logger) Error(msg string, args ...interface{}) {
 	v.log(Error, msg, args...)
 }
 
-func (v Logger) IsTrace() bool {
-	return Debug >= v.impl.GetLevel()
+// IsTrace indicates if TRACE logs would be emitted.
+// This and the other Is* guards are used to elide expensive logging code based on the current level.
+func (v *Logger) IsTrace() bool {
+	return v.Level() <= Trace
 }
 
-func (v Logger) IsDebug() bool {
-	return Debug >= v.impl.GetLevel()
+// IsDebug indicates if DEBUG logs would be emitted. This and the other Is* guards.
+// This and the other Is* guards are used to elide expensive logging code based on the current level.
+func (v *Logger) IsDebug() bool {
+	return v.Level() <= Debug
 }
 
-func (v Logger) IsInfo() bool {
-	return Debug >= v.impl.GetLevel()
+// IsInfo indicates if INFO logs would be emitted. This and the other Is* guards.
+// This and the other Is* guards are used to elide expensive logging code based on the current level.
+func (v *Logger) IsInfo() bool {
+	return v.Level() <= Info
 }
 
-func (v Logger) IsWarn() bool {
-	return Debug >= v.impl.GetLevel()
+// IsWarn indicates if WARN logs would be emitted. This and the other Is* guards.
+// This and the other Is* guards are used to elide expensive logging code based on the current level.
+func (v *Logger) IsWarn() bool {
+	return v.Level() <= Warn
 }
 
-func (v Logger) IsError() bool {
-	return Debug >= v.impl.GetLevel()
+// IsError indicates if ERROR logs would be emitted. This and the other Is* guards.
+// This and the other Is* guards are used to elide expensive logging code based on the current level.
+func (v *Logger) IsError() bool {
+	return v.Level() <= Error
 }
 
-func (v Logger) Named(name string) Logger {
+// Named creates a logger that will prepend the name string on the front of all messages.
+// If the logger already has a name, the new value will be appended to the current
+// name. That way, a major subsystem can use this to decorate all its own logs
+// without losing context.
+func (v *Logger) Named(name string) Logger {
 	return Logger{
 		v.impl.Named(name),
 	}
 }
 
-func (v Logger) ResetNamed(name string) Logger {
+// ResetNamed creates a logger that will prepend the name string on the front of all messages.
+// This sets the name of the logger to the value directly, unlike Named which honor
+// the current name as well.
+func (v *Logger) ResetNamed(name string) Logger {
 	return Logger{
 		v.impl.ResetNamed(name),
 	}
 }
 
-func (v Logger) With(args ...interface{}) Logger {
+// With creates a sublogger that will always have the given key/value pairs.
+func (v *Logger) With(args ...interface{}) Logger {
 	return Logger{
 		v.impl.With(args...),
 	}
 }
 
+// SetLevel updates the level. This should affect all related loggers as well,
+// unless they were created with IndependentLevels. If an
+// implementation cannot update the level on the fly, it should no-op.
 func (v *Logger) SetLevel(level Level) {
 	v.impl.SetLevel(level)
 }
 
-func (v *Logger) GetLevel() Level {
-	return v.impl.GetLevel()
-}
-
-func AsValue(log LogImpl) Logger {
-	return Logger{
-		impl: log,
-	}
+// Level returns the current level.
+func (v *Logger) Level() Level {
+	return v.impl.Level()
 }


### PR DESCRIPTION
* Lots of Go Doc tweaks
* Renamed `GetLevel` to `Level` to be more idiomatic Go (https://go.dev/doc/effective_go#Getters)
* Some receivers weren't using pointers (but others for the same type were), so I aligned them all to use pointers
* Tweaked the early return for `log` methods so they return if someone tries to log at `Off` level too
* I think there were bugs in `values.go` receivers for `IsX` checking for `Debug` all the time
* Some tests don't pass, but didn't seem to before either.

Just as a personal view, I'm not sure about the `LogImpl` name, but I don't know what's better, I added a `// TODO:` comment in there somewhere but it can be ignored in your PR if you'd like. I won't be too offended 😄 