### PR TITLE
.github: add recent go releases and fix missing arm go builds

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,8 +11,18 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        go-version: [1.14.x, 1.15.x, 1.16.x, 1.17.x, 1.18.x, 1.19.x]
-        os: [ubuntu-latest, windows-latest, macOS-latest]
+        go-version: [1.14.x, 1.15.x, 1.16.x, 1.17.x, 1.18.x, 1.19.x, 1.20.x, 1.21.x, 1.22.x, 1.23.x]
+        os: [ubuntu-latest, windows-latest, macos-latest]
+        exclude:
+          - go-version: 1.14.x
+            os: macos-latest
+          - go-version: 1.15.x
+            os: macos-latest
+        include:
+          - go-version: 1.14.x
+            os: macos-13
+          - go-version: 1.15.x
+            os: macos-13
     steps:
       - name: Install Go
         uses: actions/setup-go@6edd4406fa81c3da01a34fa6f6343087c207a568 # v3.5.0

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -13,6 +13,9 @@ jobs:
       matrix:
         go-version: [1.14.x, 1.15.x, 1.16.x, 1.17.x, 1.18.x, 1.19.x, 1.20.x, 1.21.x, 1.22.x, 1.23.x]
         os: [ubuntu-latest, windows-latest, macos-latest]
+        # Latest macOS version uses Apple Silicon for which there are no arm64
+        # builds prior to Go 1.16. For these versions the macOS-13 runner is used
+        # which is Intel based.
         exclude:
           - go-version: 1.14.x
             os: macos-latest


### PR DESCRIPTION
The `macos-latest` runner is now based on M1 chips meaning builds are executed on arm architectures. Go releases prior to 1.16 were not built for arm on darwin (since it didn't exist). This PR uses `macos-3` runners for 1.14-1.15 go version builders and adds recent release versions to the matrix. 