### PR TITLE
intlogger/With: reduce memory allocation

### DIFF
--- a/intlogger.go
+++ b/intlogger.go
@@ -813,7 +813,8 @@ func (l *intLogger) With(args ...interface{}) Logger {
 	// Sort keys to be consistent
 	sort.Strings(keys)
 
-	sl.implied = make([]interface{}, 0, len(l.implied)+len(args))
+	// Don't allocate for MissingKey+extra, they aren't expected to be set often.
+	sl.implied = make([]interface{}, 0, 2*len(result))
 	for _, k := range keys {
 		sl.implied = append(sl.implied, k)
 		sl.implied = append(sl.implied, result[k])


### PR DESCRIPTION
For repeated calls to `Logger.With(...)` applications might set the same set of keys multiple times, in those circumstances the size of the result map is the most correct way to determine the true number of resulting key-value pairs for the logger.

This ever so slightly reduces memory usage in the case that multiple `With` calls set the same keys, by reducing over-allocation.

Example:
```
  sl := logger.With("a", 1, "b", 2, "c", 3)
  // later
  sl.With("a", 1, "b", 2, "c", 3) // new code leaks ever so slightly less.
```

For reviewers: I kept (what appeared to be) the allocation strategy around `MissingKey` and `extra`, so callers to `With` will still perform a reallocation if they pass an odd number of parameters. They're not allocated for in the previous code (`len(l.implied)+len(args)`, ), and aren't allocated for in the new code (`2*len(result)`).