### PR TITLE
hclogvet: Fix false postive when using variadic arguments

### DIFF
--- a/hclogvet/main.go
+++ b/hclogvet/main.go
@@ -5,6 +5,7 @@ package main
 
 import (
 	"go/ast"
+	"go/token"
 	"go/types"
 	"strings"
 
@@ -64,6 +65,11 @@ func run(pass *analysis.Pass) (interface{}, error) {
 			}
 
 			if _, ok := checkHCLogFunc[fun.Sel.Name]; !ok {
+				return true
+			}
+
+			if call.Ellipsis != token.NoPos {
+				// this is a variadic function, we don't know how many args at this level
 				return true
 			}
 


### PR DESCRIPTION
This PR aims to fix #153 where `hclogvet` would incorrectly report variadic arguments as invalid, resulting in the following false positive reported by the Nomad team:

https://github.com/hashicorp/nomad/blob/8a87c335944c32b2cab3ff494259ecb42cf4473b/client/alloc_endpoint.go#L278

```console
.../nomad/client/alloc_endpoint.go:278:18: invalid number of log arguments to Info (1 valid pair only)
```

💡 **The fix is simple:** do not check the arity of variadic arguments, identified if the call contains an [ellipsis](https://pkg.go.dev/go/ast#CallExpr.Ellipsis).

> [!NOTE]
> A future improvement for this analysis (_probably_ via [SSA](https://pkg.go.dev/golang.org/x/tools/go/ssa)) could be to handle checking the value’s construction, which can happen a variety of ways. This change simply fixes the immediate problem with the analysis.