### PR TITLE
pin actions/cache to v4.2.3

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -23,13 +23,13 @@ jobs:
       - name: Checkout
         uses: actions/checkout@ac593985615ec2ede58e132d2e21d2b1cbd6127c # v3.3.0
       - name: Cache GolangCI-Lint
-        uses: actions/cache@v3
+        uses: actions/cache@5a3ec84eff668545956fd18022155c47e93e2684
         with:
           path: ~/.cache/golangci-lint
           key: golangci-lint-${{ runner.os }}-${{ hashFiles('**/go.sum') }}
           restore-keys: golangci-lint-${{ runner.os }}-
       - name: Cache Go Modules
-        uses: actions/cache@v3
+        uses: actions/cache@5a3ec84eff668545956fd18022155c47e93e2684
         with:
           path: |
               ~/go/pkg/mod


### PR DESCRIPTION
Close GitHub Code Scanning Alert [#6](https://github.com/hashicorp/go-hclog/security/code-scanning/6).
Close SECVULN-22922.