### PR TITLE
ci: Group dependabot updates for easier management.

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -9,10 +9,18 @@ updates:
       interval: weekly
     commit-message:
       prefix: "[chore] : "
-      
+    groups:
+      github-actions:
+        patterns:
+          - "*"
+
   - package-ecosystem: gomod
     directory: /
     schedule:
       interval: weekly
     commit-message:
       prefix: "[chore] : "
+    groups:
+      go:
+        patterns:
+          - "*"


### PR DESCRIPTION
Jira: https://hashicorp.atlassian.net/browse/NMD-1549
CI fixed in: https://github.com/hashicorp/go-hclog/pull/196