### PR TITLE
docs: fix Exclude godoc accuracy and comment typos

### DIFF
--- a/exclude.go
+++ b/exclude.go
@@ -10,7 +10,7 @@ import (
 
 // ExcludeByMessage provides a simple way to build a list of log messages that
 // can be queried and matched. This is meant to be used with the Exclude
-// option on Options to suppress log messages. This does not hold any mutexs
+// option on Options to suppress log messages. This does not hold any mutexes
 // within itself, so normal usage would be to Add entries at setup and none after
 // Exclude is going to be called. Exclude is called with a mutex held within
 // the Logger, so that doesn't need to use a mutex. Example usage:
@@ -32,7 +32,7 @@ func (f *ExcludeByMessage) Add(msg string) {
 	f.messages[msg] = struct{}{}
 }
 
-// Return true if the given message should be included
+// Return true if the given message should be excluded.
 func (f *ExcludeByMessage) Exclude(level Level, msg string, args ...any) bool {
 	_, ok := f.messages[msg]
 	return ok
@@ -41,7 +41,7 @@ func (f *ExcludeByMessage) Exclude(level Level, msg string, args ...any) bool {
 // ExcludeByPrefix is a simple type to match a message string that has a common prefix.
 type ExcludeByPrefix string
 
-// Matches an message that starts with the prefix.
+// Matches a message that starts with the prefix.
 func (p ExcludeByPrefix) Exclude(level Level, msg string, args ...any) bool {
 	return strings.HasPrefix(msg, string(p))
 }
@@ -57,7 +57,7 @@ func (e ExcludeByRegexp) Exclude(level Level, msg string, args ...any) bool {
 	return e.Regexp.MatchString(msg)
 }
 
-// ExcludeFuncs is a slice of functions that will called to see if a log entry
+// ExcludeFuncs is a slice of functions that will be called to see if a log entry
 // should be filtered or not. It stops calling functions once at least one returns
 // true.
 type ExcludeFuncs []func(level Level, msg string, args ...any) bool

--- a/logger.go
+++ b/logger.go
@@ -194,12 +194,12 @@ type Logger interface {
 
 	// Create a logger that will prepend the name string on the front of all messages.
 	// If the logger already has a name, the new value will be appended to the current
-	// name. That way, a major subsystem can use this to decorate all it's own logs
+	// name. That way, a major subsystem can use this to decorate all its own logs
 	// without losing context.
 	Named(name string) Logger
 
 	// Create a logger that will prepend the name string on the front of all messages.
-	// This sets the name of the logger to the value directly, unlike Named which honor
+	// This sets the name of the logger to the value directly, unlike Named which honors
 	// the current name as well.
 	ResetNamed(name string) Logger
 
@@ -307,7 +307,7 @@ type LoggerOptions struct {
 	// will not affect the parent or sibling loggers.
 	IndependentLevels bool
 
-	// When set, changing the level of a logger effects only it's direct sub-loggers
+	// When set, changing the level of a logger affects only its direct sub-loggers
 	// rather than all sub-loggers. For example:
 	// a := logger.Named("a")
 	// a.SetLevel(Error)
@@ -348,14 +348,14 @@ type InterceptLogger interface {
 	// DeregisterSink removes a SinkAdapter from the InterceptLogger
 	DeregisterSink(sink SinkAdapter)
 
-	// Create a interceptlogger that will prepend the name string on the front of all messages.
+	// Create an interceptlogger that will prepend the name string on the front of all messages.
 	// If the logger already has a name, the new value will be appended to the current
-	// name. That way, a major subsystem can use this to decorate all it's own logs
+	// name. That way, a major subsystem can use this to decorate all its own logs
 	// without losing context.
 	NamedIntercept(name string) InterceptLogger
 
-	// Create a interceptlogger that will prepend the name string on the front of all messages.
-	// This sets the name of the logger to the value directly, unlike Named which honor
+	// Create an interceptlogger that will prepend the name string on the front of all messages.
+	// This sets the name of the logger to the value directly, unlike Named which honors
 	// the current name as well.
 	ResetNamedIntercept(name string) InterceptLogger
 

--- a/stdlog.go
+++ b/stdlog.go
@@ -14,7 +14,7 @@ import (
 // beginning of inputs.
 var logTimestampRegexp = regexp.MustCompile(`^[\d\s\:\/\.\+-TZ]*`)
 
-// Provides a io.Writer to shim the data out of *log.Logger
+// Provides an io.Writer to shim the data out of *log.Logger
 // and back into our Logger. This is basically the only way to
 // build upon *log.Logger.
 type stdlogAdapter struct {


### PR DESCRIPTION
## Summary
Correct the `Exclude` helper godoc and a handful of nearby comment typos.

- `ExcludeByMessage.Exclude` returns true when a message should be **excluded** (matches `Options.Exclude` and the implementation), not included.
- `mutexs` → `mutexes`, `an message` → `a message`, `will called` → `will be called`
- `effects only it's` → `affects only its`, `a interceptlogger` → `an interceptlogger`, `a io.Writer` → `an io.Writer`
- `honor` → `honors`, `it's own` → `its own`

No behavior changes.

## Test plan
- [x] `go test ./...`