### PR TITLE
fix: Named with empty string is a no-op

### DIFF
--- a/intlogger.go
+++ b/intlogger.go
@@ -830,6 +830,10 @@ func (l *intLogger) With(args ...any) Logger {
 // Create a new sub-Logger that a name decending from the current name.
 // This is used to create a subsystem specific Logger.
 func (l *intLogger) Named(name string) Logger {
+	// Empty name would append a trailing "." (or set an empty name); treat as no-op.
+	if name == "" {
+		return l
+	}
 	sl := l.copy()
 
 	if sl.name != "" {

--- a/named_empty_test.go
+++ b/named_empty_test.go
@@ -1,0 +1,26 @@
+package hclog
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+)
+
+func TestNamedEmptyIsNoop(t *testing.T) {
+	var buf bytes.Buffer
+	l := New(&LoggerOptions{Name: "app", Level: Info, Output: &buf, DisableTime: true})
+	l.Named("").Info("hi")
+	out := buf.String()
+	if !strings.Contains(out, "app:") && !strings.Contains(out, "app") {
+		t.Fatalf("expected app name in log: %q", out)
+	}
+	if strings.Contains(out, "app.") {
+		t.Fatalf("unexpected empty name segment: %q", out)
+	}
+	buf.Reset()
+	l.Named("http").Named("").Info("x")
+	out = buf.String()
+	if !strings.Contains(out, "app.http") {
+		t.Fatalf("expected app.http: %q", out)
+	}
+}


### PR DESCRIPTION
## What

`Logger.Named("")` returns the same logger instead of appending an empty name segment.

## Why

Empty names produced loggers named like `app.` which is never useful.

## Test

- `TestNamedEmptyIsNoop`