### PR TITLE
Stabilise the sort order of log keys

### DIFF
--- a/interceptlogger_test.go
+++ b/interceptlogger_test.go
@@ -237,7 +237,7 @@ func TestInterceptLogger(t *testing.T) {
 		output := buf.String()
 		dataIdx := strings.IndexByte(output, ' ')
 		rest := output[dataIdx+1:]
-		assert.Equal(t, "[DEBUG] with_test.sub_logger.http: test1: parent=logger path=/some/test/path args=[\"test\", \"test\"]\n", rest)
+		assert.Equal(t, "[DEBUG] with_test.sub_logger.http: test1: args=[\"test\", \"test\"] parent=logger path=/some/test/path\n", rest)
 	})
 
 	t.Run("derived standard loggers send output to sinks", func(t *testing.T) {

--- a/intlogger.go
+++ b/intlogger.go
@@ -363,6 +363,8 @@ func (l *intLogger) logPlain(t time.Time, name string, level Level, msg string, 
 			}
 		}
 
+		args = sortLogArgs(args)
+
 		_ = l.writer.WriteByte(':')
 
 		// Handle the field arguments, which come in pairs (key=val).
@@ -777,6 +779,53 @@ func (l *intLogger) IsError() bool {
 }
 
 const MissingKey = "EXTRA_VALUE_AT_END"
+
+// sortLogArgs orders key/value pairs by key so unstructured (plain text)
+// log lines stay comparable across calls. MissingKey pairs stay last.
+func sortLogArgs(args []any) []any {
+	n := len(args) / 2
+	if n < 2 {
+		return args
+	}
+
+	type pair struct {
+		key any
+		val any
+		ks  string
+	}
+
+	pairs := make([]pair, 0, n)
+	extras := make([]pair, 0)
+	for i := 0; i < n; i++ {
+		k := args[i*2]
+		v := args[i*2+1]
+		var ks string
+		if s, ok := k.(string); ok {
+			ks = s
+		} else {
+			ks = fmt.Sprintf("%s", k)
+		}
+		p := pair{key: k, val: v, ks: ks}
+		if ks == MissingKey {
+			extras = append(extras, p)
+			continue
+		}
+		pairs = append(pairs, p)
+	}
+
+	sort.SliceStable(pairs, func(i, j int) bool {
+		return pairs[i].ks < pairs[j].ks
+	})
+
+	out := make([]any, 0, len(args))
+	for _, p := range pairs {
+		out = append(out, p.key, p.val)
+	}
+	for _, p := range extras {
+		out = append(out, p.key, p.val)
+	}
+	return out
+}
 
 // Return a sub-Logger for which every emitted log message will contain
 // the given key/value pairs. This is used to create a context specific

--- a/logger_test.go
+++ b/logger_test.go
@@ -407,7 +407,7 @@ func TestLogger(t *testing.T) {
 		rootLogger.Info("root_test", "bird", 10)
 		output := buf.String()
 		dataIdx := strings.IndexByte(output, ' ')
-		assert.Equal(t, "[INFO]  with_test: root_test: a=1 b=2 c=3 bird=10\n", output[dataIdx+1:])
+		assert.Equal(t, "[INFO]  with_test: root_test: a=1 b=2 bird=10 c=3\n", output[dataIdx+1:])
 
 		buf.Reset()
 
@@ -453,7 +453,7 @@ func TestLogger(t *testing.T) {
 		rootLogger.Info("root_test", "bird", 10)
 		output = buf.String()
 		dataIdx := strings.IndexByte(output, ' ')
-		assert.Equal(t, "[INFO]  with_test: root_test: a=1 b=2 c=3 bird=10\n", output[dataIdx+1:])
+		assert.Equal(t, "[INFO]  with_test: root_test: a=1 b=2 bird=10 c=3\n", output[dataIdx+1:])
 
 		buf.Reset()
 
@@ -494,7 +494,7 @@ func TestLogger(t *testing.T) {
 		dataIdx := strings.IndexByte(str, ' ')
 		rest := str[dataIdx+1:]
 
-		assert.Equal(t, "[INFO]  test: this is test: bytes=0xc perms=0755 bits=0b101\n", rest)
+		assert.Equal(t, "[INFO]  test: this is test: bits=0b101 bytes=0xc perms=0755\n", rest)
 	})
 
 	t.Run("supports quote formatting", func(t *testing.T) {
@@ -519,7 +519,7 @@ func TestLogger(t *testing.T) {
 		rest := str[dataIdx+1:]
 
 		assert.Equal(t, "[INFO]  test: this is test: "+
-			"unquoted=unquoted quoted=\"quoted\" "+
+			"quoted=\"quoted\" unquoted=unquoted "+
 			"unsafeq=\"foo\\nbar\\bbaz\\xffa\"\n", rest)
 	})
 
@@ -1230,6 +1230,27 @@ func TestLogger_JSON(t *testing.T) {
 		rest := str[dataIdx+1:]
 
 		assert.Equal(t, "[INFO]  test: who=programmer why=testing\n", rest)
+	})
+
+	t.Run("sorts field keys for stable plain output", func(t *testing.T) {
+		var buf bytes.Buffer
+
+		logger := New(&LoggerOptions{
+			Name:   "test",
+			Output: &buf,
+		})
+
+		logger.Info("retry attempt failed",
+			"count", 1,
+			"error", "unavailable",
+			"action", "scale_out",
+			"tag", "hashi-batch")
+
+		str := buf.String()
+		dataIdx := strings.IndexByte(str, ' ')
+		rest := str[dataIdx+1:]
+
+		assert.Equal(t, "[INFO]  test: retry attempt failed: action=scale_out count=1 error=unavailable tag=hashi-batch\n", rest)
 	})
 
 	t.Run("disable json escape when log special character", func(t *testing.T) {

--- a/stdlog_test.go
+++ b/stdlog_test.go
@@ -239,7 +239,7 @@ func TestFromStandardLogger(t *testing.T) {
 
 	actual := buf.String()
 	suffix := fmt.Sprintf(
-		"[INFO]  go-hclog/%s:%d: hclog-inner: this is a test: name=tester count=1\n",
+		"[INFO]  go-hclog/%s:%d: hclog-inner: this is a test: count=1 name=tester\n",
 		filepath.Base(file), line-1)
 	require.Equal(t, suffix, actual[25:])
 
@@ -268,7 +268,7 @@ func TestFromStandardLogger_helper(t *testing.T) {
 
 	actual := buf.String()
 	suffix := fmt.Sprintf(
-		"[INFO]  go-hclog/%s:%d: hclog-inner: this is a test: name=tester count=1\n",
+		"[INFO]  go-hclog/%s:%d: hclog-inner: this is a test: count=1 name=tester\n",
 		filepath.Base(file), line-1)
 	require.Equal(t, suffix, actual[25:])
 


### PR DESCRIPTION
Plain text log lines currently print field keys in the order they were passed. That makes STDERR hard to compare when callers build fields from a map.

This sorts field keys before writing plain text output. EXTRA_VALUE_AT_END stays last. JSON output is unchanged.

Fixes #163